### PR TITLE
setup: declare alpha release

### DIFF
--- a/.github/Githubfile
+++ b/.github/Githubfile
@@ -3,7 +3,14 @@ owner = jacquerie
 repo = github-file
 description = Configure your GitHub repository from a file,
     without having to click around in the UI.
+topics = github, configuration, file
 
 [features]
 has_issues = true
+has_projects = false
 has_wiki = false
+
+[merges]
+allow_squash_merge = false
+allow_merge_commit = false
+allow_rebase_merge = true

--- a/README.rst
+++ b/README.rst
@@ -49,17 +49,21 @@ matches what is described in a file called (by default) ``Githubfile`` in the
 
     [features]
     has_issues = true
+    has_projects = false
     has_wiki = false
+
+    [merges]
+    allow_squash_merge = false
+    allow_merge_commit = false
+    allow_rebase_merge = true
 
 The meaning of these options is explained in GitHub's API documentation at
 https://developer.github.com/v3/repos/#edit, although not all options are
-currently available. Here's what's currently configurable:
+currently available. Here's what's currently not configurable:
 
-- ``description``
-- ``homepage``
-- ``private``
-- ``has_issues``
-- ``has_wiki``
+- Whether the repository is archived.
+- The configuration of the branches.
+- The topics of the repository.
 
 
 Author

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ matches what is described in a file called (by default) ``Githubfile`` in the
     repo = github-file
     description = Configure your GitHub repository from a file,
         without having to click around in the UI.
+    topics = github, configuration, file
 
     [features]
     has_issues = true
@@ -63,7 +64,6 @@ currently available. Here's what's currently not configurable:
 
 - Whether the repository is archived.
 - The configuration of the branches.
-- The topics of the repository.
 
 
 Author

--- a/README.rst
+++ b/README.rst
@@ -29,15 +29,16 @@ Install
 Usage
 =====
 
-Currently ``github-file`` implements one subcommand:
+First, you will need to provide your GitHub credentials through the
+environment.  Since ``github-file`` uses ``python-dotenv`` you can do so by
+creating a ``.env`` file with the following contents:
 
-.. code-block:: console
+.. code-block:: shell
 
-    $ github-file update
+    GITHUB_USER=your_username
+    GITHUB_PASS=your_password
 
-This will update the configuration of your repository on GitHub so that it
-matches what is described in a file called (by default) ``Githubfile`` in the
-``.github`` folder. Here's an example of such a file:
+Next, you will need to create a valid ``Githubfile``. Here's an example of one:
 
 .. code-block:: ini
 
@@ -58,12 +59,21 @@ matches what is described in a file called (by default) ``Githubfile`` in the
     allow_merge_commit = false
     allow_rebase_merge = true
 
-The meaning of these options is explained in GitHub's API documentation at
-https://developer.github.com/v3/repos/#edit, although not all options are
-currently available. Here's what's currently not configurable:
+The meaning of these options is explained in `GitHub's API documentation`_,
+although not all the options are currently supported (in particular you
+currently can't archive the repository or configure the default branch.)
 
-- Whether the repository is archived.
-- The configuration of the branches.
+Finally, running
+
+.. code-block:: console
+
+    $ github-file update -f Githubfile
+
+will update the configuration of your GitHub repository so that it matches what
+is described in the file. Note that if you don't provide a filename it will
+look by default in ``.github/Githubfile``.
+
+.. _`GitHub's API documentation`: https://developer.github.com/v3/repos/#edit
 
 
 Author

--- a/github_file/cli.py
+++ b/github_file/cli.py
@@ -41,16 +41,33 @@ def update(filename):
     has_issues = True
     if parser.has_option('features', 'has_issues'):
         has_issues = parser.getboolean('features', 'has_issues')
+    has_projects = True
+    if parser.has_option('features', 'has_projects'):
+        has_projects = parser.getboolean('features', 'has_projects')
     has_wiki = True
     if parser.has_option('features', 'has_wiki'):
         has_wiki = parser.getboolean('features', 'has_wiki')
+
+    allow_squash_merge = True
+    if parser.has_option('merges', 'allow_squash_merge'):
+        allow_squash_merge = parser.getboolean('merges', 'allow_squash_merge')
+    allow_merge_commit = True
+    if parser.has_option('merges', 'allow_merge_commit'):
+        allow_merge_commit = parser.getboolean('merges', 'allow_merge_commit')
+    allow_rebase_merge = True
+    if parser.has_option('merges', 'allow_rebase_merge'):
+        allow_rebase_merge = parser.getboolean('merges', 'allow_rebase_merge')
 
     config = {
         'description': description,
         'homepage': homepage,
         'private': private,
         'has_issues': has_issues,
+        'has_projects': has_projects,
         'has_wiki': has_wiki,
+        'allow_squash_merge': allow_squash_merge,
+        'allow_merge_commit': allow_merge_commit,
+        'allow_rebase_merge': allow_rebase_merge,
     }
 
     github_user = os.getenv('GITHUB_USER')

--- a/github_file/cli.py
+++ b/github_file/cli.py
@@ -37,6 +37,9 @@ def update(filename):
     private = False
     if parser.has_option('core', 'private'):
         private = parser.getboolean('core', 'private')
+    topics = []
+    if parser.has_option('core', 'topics'):
+        topics = parser.get('core', 'topics').split(', ')
 
     has_issues = True
     if parser.has_option('features', 'has_issues'):
@@ -76,3 +79,4 @@ def update(filename):
 
     repository = github.repository(owner, repo)
     repository.edit(repo, **config)
+    repository.replace_topics(topics)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup_requires = [
 install_requires = [
     'click~=6.0,>=6.7',
     'github3.py~=1.0,>=1.1.0',
-    'python-dotenv~=0.0,>=0.8.2',
+    'python-dotenv~=0.0,>=0.8.2,<0.9.0',
     'six~=1.0,>=1.11.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup_requires = [
 
 install_requires = [
     'click~=6.0,>=6.7',
-    'github3.py~=1.0,>=1.1.0',
+    'github3.py~=1.0,>=1.2.0',
     'python-dotenv~=0.0,>=0.8.2,<0.9.0',
     'six~=1.0,>=1.11.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         ],
     },
     classifiers=[
-        'Development Status :: 1 - Planning',
+        'Development Status :: 3 - Alpha',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',

--- a/tests/cassettes/test_update_can_configure_the_issue_labels.yaml
+++ b/tests/cassettes/test_update_can_configure_the_issue_labels.yaml
@@ -1,0 +1,649 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: GET
+    uri: https://api.github.com/repos/jacquerie/github-file
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WYXW/bNhSG/8qg2yWh5ThfAoKuQIMiw5J2g7cVuTFoibaYSKJKUnYTIf99Lz9k
+        SV5hJ9ZNoNA8D18eHpLnsA54EkThZHR2FU7OwqOgEAmbmbbg7tPN+kv2exZ/vnqh3/5axcXTj/tP
+        H8Mv05vR/fTmOkBnmjP0XHKdVvPjBc8YGhdVls38L480/l4xyRnp9xHrgskgqoNMLHkBxKYjAGb0
+        08twfDnqy/nz/J9v91n8eDe5m95O7j5eGwl0RTWVs0pmoKRalyoixDWq8YkbtVJMxqLQrNAnschJ
+        RRz+w+p6AsRSeoidNhq2YCX3HGcMmCJdvanOsy0Bblzbv9tzIbJMrGG/rXfnEGRjZrxrEbxYHoKA
+        WU2EThkchmm8mslzpd8px5rUWFGlESkGorAEkiXvk+SNIMgEw2tNJCuFpVVzFUteai6Kd0rrmQIl
+        5JIW/IUegIKpAsGIeqcIawJTtkLAvdPW2dSklHxF42fjDslixlfw7iG8LWPg9HNp9uzfWH/ja67Z
+        jCa52YQLmin2ehTYsTU62YYj7Ko3xffWFk/YZhGDqMCZYGJXPm2oOzeZdWG7dbbQhrPHrzsA2E4w
+        x9yf2PMAirGuCf76PRBjY9K5kFSLfft7l7gepibdf00waEbzAaKtOTCpEEM8aM2B4UpV7E1xuWvK
+        lqJIE/pFlc/d2fSWgN8FdvbQSZXiy4KxAZ7bIGrSHJ1zSYs4HQJtCDVxX3aF6XKATGMNyDwT8wEU
+        XF/EImqiUuquCT0bpswwDaGHlGwxUKYhbJBaDlpjK9EgNkDcURrLPUBjQyC192RGi2VFl0OYG4Q5
+        wHH1LunL3pxi1z5pGQCaREnyeTX0GGspRqW70rGvh7iyhbRImyXsTjx2Tr2Ta9jJ5znfd2fv4nlA
+        L8gHQ01cboPN//vTi31SDaEm7YnrDnTPPtyr/kRvNHZH8Hn4gDBoCKT+taQ6NacTBiqpZIcL9gBS
+        zylSoJOTkzpl1Ka2OZOD9qqzB4jKOEUad7jGuiEgf8mptgnzwkhMkEBngiYDfLpBAOcW73Cdzr67
+        5iWyvwHirHmXl6PQVFoUQ87QltElF0LzBY/fUi/s2lo9TP1B8SJmRxQpMKJU85gjblGKmbVDysiG
+        +MbZYwqoxF2xkDGE8ABvS+YINXG1XcLKTDwPPGs6ELNdJUN9kcyoRiEyHoWXx6OL4zCchmfRKIwm
+        owf0qcrk/33GF9PwKjq9iEbnpk9ZqXQbMx5Px6MoHEfhmemCo9NHMr7wMvCzwrxbXZhKH2ZKpa3Z
+        b61R9NMHDW8UZwjJrX3z1vFW23fYPkOITEXOSmQS7tFC8Rd8nU56KUEsqgJOPj0K1lQjV8X12zY1
+        aQTsvz7rVBSGSdXMbeAg0rIy1R9aSikeWaxVt609Mjod1/yJ9wxNorMp+Vzd5gXgcSfnUgr/duMq
+        RH/E4R3G156iZIUX1CjHI1XGY1YoTLc2RRz049KGeP/odHc7/eUP3wPeKJMf/kHrdmoCq/9S1H95
+        8WBFPLDzGBafTz9njw//nr08TG9eAtTJro6MMJGOSjymtc62nk/YglaZnrkU34ilStviu2Qyh7PN
+        M4eZii/DndtNbDeeNAeg+8aoOEbEeqa+VxQxam+Xppv7xTbBVyaR6f8imbnd+jYF02uUw41vMZdu
+        quaXKnz9D4Er7fMnFAAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:17 GMT']
+      etag: [W/"10f33307eb5017cfc02320f4f8a41cc8"]
+      last-modified: ['Fri, 27 Jul 2018 19:37:06 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF7344:D7C93B8:5B5B746D']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4859']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.061413']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"has_wiki": true, "description": "", "allow_squash_merge":
+      true, "private": false, "has_issues": true, "allow_rebase_merge": true, "name":
+      "github-file", "allow_merge_commit": true, "has_projects": true, "homepage":
+      ""}'
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['220']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: PATCH
+    uri: https://api.github.com/repos/jacquerie/github-file
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WYXW/bNhSG/8qg2yWR5ThtIiDoCjQoMixpN3hbkRuDlmiLiSSqJGU3FvLf9/JD
+        luQVdmLeBArN8/Dl4SF5DpuApUEcTUYXV9HkIjoJSp7SmW4L7j7drL/kv+fJ56sN+fbXKimfftx/
+        +hh9md6M7qc31wE6k4Ki55KprJ6fLlhO0bio83zmfnkkyfeaCkbDYR++LqkI4ibI+ZKVQGw7AqBH
+        P7+MxpejoZw/3/3z7T5PHu8md9Pbyd3Hay2BrIgiYlaLHJRMqUrGYWgb5fjMjlpLKhJeKlqqs4QX
+        YR1a/IfV9QSIpXAQM2007MAq5jjWGDAZ9vVmqsh3BNhxTf9+zwXPc76G/a7evUOEWzPtXYNg5fIY
+        BMyakKuMwmGYxouePJPqjXKMSYMVlQqRoiESSyBo+jZJzgiCdDC8NKGgFTe0ei4TwSrFePlGaQNT
+        oLhYkpJtyBEomEoQtKg3ijAmMKUrBNwbba1NE1aCrUjyrN0haELZCt49hrdjDJx6rvSe/Rvrr33N
+        FJ2RtNCbcEFySV9OAjO2QifTcIJd9ar43tniKd0uYhCXOBN07IqnLXXvJjMu7LbODlpzDvh1DwDb
+        CeaY+xN99qBo6ybEX7cHEmxMMueCKH5of+8TN8A0Yf9fHQyKksJDtDEHJuPcx4PGHBgmZU1fFZf7
+        pmwoMmxDv6yLuT2bXhPw+8DWHjqJlGxZUurhuS2iCdujcy5ImWQ+0JbQhPbLrDBZesjU1oDMcz73
+        oOD6Cg2iCWVG7DWhZn7KNFMTBkhBF54yNWGLVMJrjY1EjdgCcUcpLLeHxpYQNs6TOSmXNVn6MLcI
+        fYDj6l2SzcGcYt8+6RgA6kRJsHnte4x1FK3SXunY1z6u7CAd0mQJ+xOPvVPv5Rpm8kXBDt3Z+3gO
+        MAhyb6iOy12w/v9wenFIqiY0YXfi2gPdsY/3qjvRW439EVwe7hEGLSFsfq2IyvTphIEqIujxgh0g
+        bOYEKdDZ2VmTUWJS24IKr71q7QEiIsmQxh2vsWkJyF8KokzCvNASUyTQOSeph0+3CODs4h2v09r3
+        17xC9uchzpj3eQUKTal46XOGdow+ueSKLVjymnph39YaYJoPkpUJPSFIgRGliiUMcYtSTK8dUkbq
+        4xtrjymgErfFQk4Rwh7eFtQSmtDWdimtcv7sedb0IHq7Cor6Ip0RhUJkPIouT0fvT6NoGl3Eoyie
+        jB7Qp67S//cZv59GV/H5+zi61H2qWma7mPF4Oh7F0TiOLnQXHJ0ukvGFl4GfFeb96kJX+jCTMuvM
+        fuuM4p8+aDijJEdI7uyb14632r3DDhlCZMYLWiGTsI8Wkm3wdT4ZpAQJr0s4+fwkWBOFXBXXb9fU
+        phGw//qsMl5qJpEzu4GDWIlaV39oqQR/pImS/bbuyOh1XLMnNjDUic625LN1mxOAx52CCcHd242t
+        EN0Rh3cYV3vyipZOUKscj1Q5S2gpMd1GF3HQj0sb4t2j093t9Jc/XA94o0p/uAet26kOrOFL0fDl
+        xYFl6IC9x7Dk3fRz/vjw78XmYXqzCVAn2zoyxkR6KvGY1jnbeD6lC1LnamZTfC2WSGWK74qKAs7W
+        zxx6Kq4Mt27Xsd16Uh+A9huj4hjh65n8XhPEqLld2m72F9MEX+lEZviLoPp2G9qUVK1RDre+xVz6
+        qZpbqujlP92EL3UnFAAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:18 GMT']
+      etag: [W/"f93b614f351a7d1e559249632f838e85"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF73A4:D7C944E:5B5B746D']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4858']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.091903']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"names": []}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.mercy-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['13']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: PUT
+    uri: https://api.github.com/repos/jacquerie/github-file/topics
+  response:
+    body: {string: !!python/unicode '{"names":[]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['12']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:18 GMT']
+      etag: ['"ea090b1b7f4cdcab6bd9de862e56f062"']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.mercy-preview; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF740F:D7C951A:5B5B746E']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4857']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.088531']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: GET
+    uri: https://api.github.com/repos/jacquerie/github-file/labels?per_page=100
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA63VUW+bMBAH8K9iIU19yQpNUkjzNilrn7KXdZq2aZocfIBXYzP7PNJN/e47SAld
+        UxUeyAvyGVn6cf5fvv0NpAjWF1GURFfzRbycBdoI+NEUg+3mU3x7cy2/fq732827xXZzd7/98yUK
+        ZoG3il4oECu3DkNeyfNcYuF356kpQwuVceFPnv7yYCWEh623mVQQKr4D5cKdz+kUzUugYw6L1Chj
+        aSWSBV9y2hWQca8wWKP10CxdamWF0mh666MpAQupcyadPkNWG3tHq+Bh9kx0OUJ0MYFI+ErJlCP0
+        rqelTpdmYiGSId1tIR3BnAdmLKu8UswCfU2HjCsLXNwz2EuH7tQbj/DOJ/CCLrhOoQSNvfj/Ymfm
+        cwDIhswfoGYZcPS2RT96T4HJCOBiAmBujHgzjzJpHdKz7UYvbXZZu3foE+103CS6TLJB7k17AEE1
+        1BQasKe9TEbc3XSKu1uAqohYc40gemNTZsdix4uiVZw0N+jVfL7fo+WMI9L9oMTSRyIoCDr+eUJX
+        I5T5FEqpf3NFg+04d/pCZ4MlxPHVkK1NpzDQDh4HUDIr8wJPZSOymE+RxXYyNHPxSHtSOc7VVRJD
+        E4xX+3btLRZgmdR0N0ve9e4xjS+1b0Qe8ynyWBuNmdz3xr7QEbP2N0Rs21dLmqnaINtB+98BgtH3
+        e/j+Dx6SZbURBwAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:18 GMT']
+      etag: [W/"db3d6e38d20e63e41fc008b648a20996"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF7464:D7C95C8:5B5B746E']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4856']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.080138']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/bug
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:19 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF74CB:D7C9672:5B5B746E']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4855']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.093267']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/duplicate
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:19 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF7526:D7C9729:5B5B746F']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4854']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.097986']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/enhancement
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:19 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF7599:D7C97D6:5B5B746F']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4853']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.091035']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:20 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF7623:D7C989C:5B5B746F']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4852']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.087390']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:20 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF768C:D7C9983:5B5B7470']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4851']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.086104']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/invalid
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:20 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF7705:D7C9A31:5B5B7470']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4850']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.082462']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/question
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:21 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF776C:D7C9B01:5B5B7470']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4849']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.075767']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/wontfix
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:21 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF77E4:D7C9BC7:5B5B7471']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4848']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.073178']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{"color": "a2eeef", "name": "enhancement"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['42']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092517,"node_id":"MDU6TGFiZWwxMDA3MDkyNTE3","url":"https://api.github.com/repos/jacquerie/github-file/labels/enhancement","name":"enhancement","color":"a2eeef","default":true,"description":null}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['204']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:21 GMT']
+      etag: ['"0f69b52c8a52bc464c39a985fbaddc65"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/enhancement']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF7844:D7C9CAB:5B5B7471']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4847']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.067191']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "d73a4a", "name": "bug"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['34']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092525,"node_id":"MDU6TGFiZWwxMDA3MDkyNTI1","url":"https://api.github.com/repos/jacquerie/github-file/labels/bug","name":"bug","color":"d73a4a","default":true,"description":null}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['188']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:21 GMT']
+      etag: ['"27f9885422dc50fa8339e6205e87acda"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/bug']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF789E:D7C9D68:5B5B7471']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4846']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.072936']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "d876e3", "name": "question"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['39']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092527,"node_id":"MDU6TGFiZWwxMDA3MDkyNTI3","url":"https://api.github.com/repos/jacquerie/github-file/labels/question","name":"question","color":"d876e3","default":true,"description":null}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['198']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:22 GMT']
+      etag: ['"3588e6f7fa323467a852e9dcaf933e9f"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/question']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBF4:5CB0:6FF78E6:D7C9DFF:5B5B7471']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4845']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.066662']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+version: 1

--- a/tests/cassettes/test_update_can_configure_the_merge_policy.yaml
+++ b/tests/cassettes/test_update_can_configure_the_merge_policy.yaml
@@ -1,0 +1,876 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: GET
+    uri: https://api.github.com/repos/jacquerie/github-file
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WYXW/bNhSG/8qg2yWh5ThtIiDoCjQoMixpN3hbkRuDlmiLiSSqJGU3FvLf9/JD
+        luQVdmLdBArN8/Dl4SF5DuuAJ0EUTkYXV+HkIjwJCpGwmWkL7j7drL9kv2fx56sN/fbXKi6eftx/
+        +hh+md6M7qc31wE605yh55LrtJqfLnjG0Liosmzmf3mk8feKSc5Iv49YF0wGUR1kYskLILYdATCj
+        n1+G48tRX86f7/75dp/Fj3eTu+nt5O7jtZFAV1RTOatkBkqqdakiQlyjGp+5USvFZCwKzQp9Fouc
+        VMThP6yuJ0AspYfYaaNhB1Zyz3HGgCnS1ZvqPNsR4Ma1/bs9FyLLxBr2u3r3DkG2Zsa7FsGL5TEI
+        mNVE6JTBYZjGi5k8V/qNcqxJjRVVGpFiIApLIFnyNkneCIJMMLzURLJSWFo1V7HkpeaieKO0nilQ
+        Qi5pwTf0CBRMFQhG1BtFWBOYshUC7o22zqYmpeQrGj8bd0gWM76Cd4/h7RgDp59Ls2f/xvobX3PN
+        ZjTJzSZc0Eyxl5PAjq3RyTacYFe9Kr53tnjCtosYRAXOBBO78mlL3bvJrAvbrbODNpwDft0DwHaC
+        Oeb+xJ4HUIx1TfDX74EYG5POhaRaHNrf+8T1MDXp/muCQTOaDxBtzYFJhRjiQWsODFeqYq+Ky31T
+        thRFmtAvqnzuzqbXBPw+sLOHTqoUXxaMDfDcFlGT5uicS1rE6RBoQ6iJ+7IrTJcDZBprQOaZmA+g
+        4PoiFlETlVJ3TejZMGWGaQg9pGSLgTINYYvUctAaW4kGsQXijtJY7gEaGwKpvSczWiwruhzC3CLM
+        AY6rd0k3B3OKffukZQBoEiXJ59XQY6ylGJXuSse+HuLKFtIibZawP/HYO/VOrmEnn+f80J29j+cB
+        vSAfDDVxuQs2/x9OLw5JNYSatCeuO9A9+3iv+hO90dgdwefhA8KgIZD615Lq1JxOGKikkh0v2ANI
+        PadIgc7OzuqUUZva5kwO2qvOHiAq4xRp3PEa64aA/CWn2ibMCyMxQQKdCZoM8OkWAZxbvON1Ovvu
+        mpfI/gaIs+ZdXo5CU2lRDDlDW0aXXAjNFzx+Tb2wb2v1MPUHxYuYnVCkwIhSzWOOuEUpZtYOKSMb
+        4htnjymgEnfFQsYQwgO8LZkj1MTVdgkrM/E88KzpQMx2lQz1RTKjGoXIeBReno7en4bhNLyIRmE0
+        GT2gT1Um/+8zfj8Nr6Lz99H52PQpK5XuYsbj6XgUheMovDBdcHT6SMYXXgZ+Vph3qwtT6cNMqbQ1
+        +601in76oOGN4gwhubNvXjveavcOO2QIkanIWYlMwj1aKL7B1/mklxLEoirg5POTYE01clVcv21T
+        k0bA/uuzTkVhmFTN3AYOIi0rU/2hpZTikcVaddvaI6PTcc2feM/QJDrbks/VbV4AHndyLqXwbzeu
+        QvRHHN5hfO0pSlZ4QY1yPFJlPGaFwnRrU8RBPy5tiPePTne301/+8D3gjTL54R+0bqcmsPovRf2X
+        Fw9WxAM7j2Hxu+nn7PHh34vNw/RmE6BOdnVkhIl0VOIxrXW29XzCFrTK9Myl+EYsVdoW3yWTOZxt
+        njnMVHwZ7txuYrvxpDkA3TdGxTEi1jP1vaKIUXu7NN3cL7YJvjKJTP8Xyczt1rcpmF6jHG58i7l0
+        UzW/VOHLfwzXMnQnFAAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:44 GMT']
+      etag: [W/"ccb3354f0eda7f6a8aed00728ce8817d"]
+      last-modified: ['Fri, 27 Jul 2018 19:37:32 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF9361:D7CCFB2:5B5B7488']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4829']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.106339']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"has_wiki": true, "description": "", "allow_squash_merge":
+      false, "private": false, "has_issues": true, "allow_rebase_merge": true, "name":
+      "github-file", "allow_merge_commit": false, "has_projects": true, "homepage":
+      ""}'
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['222']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: PATCH
+    uri: https://api.github.com/repos/jacquerie/github-file
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WYXW/bNhSG/8qg2yWR5ThtIiDoCjQoMixpN3hbkRuDlmiLiSSqJGU3FvLf9/JD
+        H/YKOzFvAoXmefjy8JA8h03A0iCOJqOLq2hyEZ0EJU/pTLcFd59u1l/y3/Pk89WGfPtrlZRPP+4/
+        fYy+TG9G99Ob6wCdSUHRc8lUVs9PFyynaFzUeT5zvzyS5HtNBaPhdh++LqkI4ibI+ZKVQHQdAdCj
+        n19G48vRtpw/3/3z7T5PHu8md9Pbyd3Hay2BrIgiYlaLHJRMqUrGYWgb5fjMjlpLKhJeKlqqs4QX
+        YR1a/IfV9QSIpXAQM2007MAq5jjWGDAZDvVmqsh3BNhxTf9hzwXPc76G/a7evUOEnZn2rkGwcnkM
+        AmZNyFVG4TBM40VPnkn1RjnGpMGKSoVI0RCJJRA0fZskZwRBOhhemlDQihtaPZeJYJVivHyjtC1T
+        oLhYkpJtyBEomEoQtKg3ijAmMKUrBNwbba1NE1aCrUjyrN0haELZCt49hrdjDJx6rvSe/Rvrr33N
+        FJ2RtNCbcEFySV9OAjO2QifTcIJd9ar43tniKe0WMYhLnAk6dsVTR927yYwL+62zg9acA37dA8B2
+        gjnm/kSfPSjaugnx1+2BBBuTzLkgih/a3/vEbWGacPivDgZFSeEh2pgDk3Hu40FjDgyTsqavist9
+        UzYUGbahX9bF3J5Nrwn4fWBrD51ESrYsKfXwXIdowvbonAtSJpkPtCU0of0yK0yWHjK1NSDznM89
+        KLi+QoNoQpkRe02omZ8yzdSELaSgC0+ZmtAhlfBaYyNRIzog7iiF5fbQ2BLCxnkyJ+WyJksfZofQ
+        Bziu3iXZHMwp9u2TngGgTpQEm9e+x1hP0SrtlY597ePKHtIjTZawP/HYO/VBrmEmXxTs0J29j+cA
+        W0HuDdVxuQvW/x9OLw5J1YQm7E9ce6A79vFedSd6q3E4gsvDPcKgJYTNrxVRmT6dMFBFBD1esAOE
+        zZwgBTo7O2sySkxqW1DhtVetPUBEJBnSuOM1Ni0B+UtBlEmYF1piigQ65yT18GmHAM4u3vE6rf1w
+        zStkfx7ijPmQV6DQlIqXPmdozxiSS67YgiWvqRf2ba0tTPNBsjKhJwQpMKJUsYQhblGK6bVDykh9
+        fGPtMQVU4rZYyClC2MPbglpCE9raLqVVzp89z5oBRG9XQVFfpDOiUIiMR9Hl6ej9aRRNo4t4FMWT
+        0QP61FX6/z7j99PoKj5/H08muk9Vy2wXMx5Px6M4GsfRhe6Co9NFMr7wMvCzwnxYXehKH2ZSZr3Z
+        b71R/NMHDWeU5AjJnX3z2vFWu3fYIUOIzHhBK2QS9tFCsg2+zidbKUHC6xJOPj8J1kQhV8X12ze1
+        aQTsvz6rjJeaSeTMbuAgVqLW1R9aKsEfaaLksK0/MgYd1+yJbRnqRKcr+Wzd5gTgcadgQnD3dmMr
+        RHfE4R3G1Z68oqUT1CrHI1XOElpKTLfRRRz049KGePfodHc7/eUP1wPeqNIf7kHrdqoDa/ulaPvl
+        xYFl6ICDx7Dk3fRz/vjw78XmYXqzCVAn2zoyxkQGKvGY1jvbeD6lC1LnamZTfC2WSGWK74qKAs7W
+        zxx6Kq4Mt27Xsd16Uh+A9huj4hjh65n8XhPEqLldOmfZn0wbnKUzmZ2fBNX3W2tlByqpWqMgbr2L
+        2QyTNbdY0ct//N3CJCkUAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:44 GMT']
+      etag: [W/"618e36af0850fafeae04b496d031f374"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF93A5:D7CD062:5B5B7488']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4828']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.088698']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"names": []}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.mercy-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['13']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: PUT
+    uri: https://api.github.com/repos/jacquerie/github-file/topics
+  response:
+    body: {string: !!python/unicode '{"names":[]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['12']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:45 GMT']
+      etag: ['"ea090b1b7f4cdcab6bd9de862e56f062"']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.mercy-preview; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF93DD:D7CD0CD:5B5B7488']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4827']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.098253']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: GET
+    uri: https://api.github.com/repos/jacquerie/github-file/labels?per_page=100
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62V0W+bMBDG/xULadpLVmgg0ORtUtZqD6kUrdOkTdPk4CO4NTazj5Fu6v++g5TQ
+        NtWINHhB/g6d9LvP9/HtjyeFtzgPgiSYT+NpNPG0EfCjEb3V8nN8c3Upv36pd6vl+3C1vLu/vv0Y
+        eBOvsoo+yBFLt/B9XsqzrcS82pylpvAtlMb5tzz9WYGV4O9L7zKpwFd8A8r5m2pLXTQvgNrsD6lR
+        xtJJJCGPOFUFZLxS6C3QVtAcXWplidJo+uqTKQBzqbdMOv0WWW3sHZ28h8kLouQEonAEIlGVSqYc
+        oed6KnV0aSZCkQzR3eTSEZirgBnLykopZoGm6ZBxZYGLewY76dAd8YbzYd7VbARe0DnXKRSgsSd+
+        LnbMfAoA2RDzNdQsA46VbaEfeY8Ao3AYcP17BMCtMeLNNMikdUjv1o2etKmytrb3iSodbhLMkmwQ
+        96ptQKAaaloasMdeRids43qMbcxBlYRYc40gesZGZgexwwuCiziZDrn5YYeWM45I94M2loZEoCCo
+        /csNjWYnGHo+gqFS/+KKgu2QO73QsUEEcTwfYmu3Uxhog8cBFMzKbY7HZPEJZM0k/zdN22RocvGA
+        9kQ55OpFEkOTdP/M1cvKYg6WSU13s+Cdd4/b+Jp9JwTseoyArY3GTO56xl7oELP2GUJs7aslZao2
+        yDbQ/jtAMJrfw/e/EnQdCBEHAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:45 GMT']
+      etag: [W/"8ff3f7d7f454f23d0a706882ea4c33c5"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF9422:D7CD153:5B5B7489']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4826']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.063771']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/bug
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:45 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF946E:D7CD1C8:5B5B7489']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4825']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.068767']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/duplicate
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:45 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF94B4:D7CD253:5B5B7489']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4824']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.085648']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/enhancement
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:46 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF9506:D7CD2CD:5B5B7489']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4823']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.075874']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:46 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF9548:D7CD359:5B5B748A']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4822']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.091449']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:46 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF95A1:D7CD3F0:5B5B748A']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4821']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.062965']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/invalid
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:46 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF95E4:D7CD488:5B5B748A']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4820']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.088049']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/question
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:47 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF9624:D7CD500:5B5B748A']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4819']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.080556']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/wontfix
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:37:47 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF966B:D7CD57F:5B5B748B']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4818']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.070457']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{"color": "d73a4a", "name": "bug", "description": "Something
+      isn''t working"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['76']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092752,"node_id":"MDU6TGFiZWwxMDA3MDkyNzUy","url":"https://api.github.com/repos/jacquerie/github-file/labels/bug","name":"bug","color":"d73a4a","default":true,"description":"Something
+        isn''t working"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['209']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:47 GMT']
+      etag: ['"1c0f3a22cd13db7e74927be2aa69020f"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/bug']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF96A8:D7CD5FF:5B5B748B']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4817']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.062256']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "cfd3d7", "name": "duplicate", "description":
+      "This issue or pull request already exists"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092753,"node_id":"MDU6TGFiZWwxMDA3MDkyNzUz","url":"https://api.github.com/repos/jacquerie/github-file/labels/duplicate","name":"duplicate","color":"cfd3d7","default":true,"description":"This
+        issue or pull request already exists"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['239']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:47 GMT']
+      etag: ['"e0e62ba9e13ed8c2bc6a3b5034ab9fbd"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/duplicate']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF96E2:D7CD661:5B5B748B']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4816']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.068183']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "a2eeef", "name": "enhancement", "description":
+      "New feature or request"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['83']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092762,"node_id":"MDU6TGFiZWwxMDA3MDkyNzYy","url":"https://api.github.com/repos/jacquerie/github-file/labels/enhancement","name":"enhancement","color":"a2eeef","default":true,"description":"New
+        feature or request"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['224']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:48 GMT']
+      etag: ['"20ae544031c83d98c04cd1637ee70a9a"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/enhancement']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF971E:D7CD6C9:5B5B748B']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4815']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.056364']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "7057ff", "name": "good first issue", "description":
+      "Good for newcomers"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['84']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092763,"node_id":"MDU6TGFiZWwxMDA3MDkyNzYz","url":"https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue","name":"good
+        first issue","color":"7057ff","default":true,"description":"Good for newcomers"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['234']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:48 GMT']
+      etag: ['"3da25e07ba7e166c0bb2e4636bb88091"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF976E:D7CD72F:5B5B748C']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4814']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.070738']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "008672", "name": "help wanted", "description":
+      "Extra attention is needed"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['86']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092788,"node_id":"MDU6TGFiZWwxMDA3MDkyNzg4","url":"https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted","name":"help
+        wanted","color":"008672","default":true,"description":"Extra attention is
+        needed"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['229']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:48 GMT']
+      etag: ['"07c915d9094a5fd4f987f8ba7bc5a684"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF97BA:D7CD7CC:5B5B748C']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4813']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.064340']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "e4e669", "name": "invalid", "description":
+      "This doesn''t seem right"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['80']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092797,"node_id":"MDU6TGFiZWwxMDA3MDkyNzk3","url":"https://api.github.com/repos/jacquerie/github-file/labels/invalid","name":"invalid","color":"e4e669","default":true,"description":"This
+        doesn''t seem right"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['217']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:48 GMT']
+      etag: ['"0ef44e992b4ab5276afe55987013f256"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/invalid']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF980E:D7CD853:5B5B748C']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4812']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.075210']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "d876e3", "name": "question", "description":
+      "Further information is requested"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['90']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092808,"node_id":"MDU6TGFiZWwxMDA3MDkyODA4","url":"https://api.github.com/repos/jacquerie/github-file/labels/question","name":"question","color":"d876e3","default":true,"description":"Further
+        information is requested"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['228']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:49 GMT']
+      etag: ['"6871c1c208e4252bb7f0857abb02db4c"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/question']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF9859:D7CD8EC:5B5B748C']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4811']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.068279']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "ffffff", "name": "wontfix", "description":
+      "This will not be worked on"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['83']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092815,"node_id":"MDU6TGFiZWwxMDA3MDkyODE1","url":"https://api.github.com/repos/jacquerie/github-file/labels/wontfix","name":"wontfix","color":"ffffff","default":true,"description":"This
+        will not be worked on"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['220']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:49 GMT']
+      etag: ['"654018c1c6b4263d6e526c67ac768201"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/wontfix']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCF2:5CB0:6FF98A3:D7CD973:5B5B748D']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4810']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.068772']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+version: 1

--- a/tests/cassettes/test_update_can_configure_which_features_to_use.yaml
+++ b/tests/cassettes/test_update_can_configure_which_features_to_use.yaml
@@ -1,0 +1,876 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: GET
+    uri: https://api.github.com/repos/jacquerie/github-file
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WYXW/bNhSG/8qg2yWh5ThpIiDoCjQoMixtN3hbkRuDlmiLiSSqJGU3FvLf9/JD
+        luQVdmLdBArN8/Dl4SF5DuuAJ0EUTkYX1+HkIjwJCpGwmWkL7j/err9kv2fxp+sN/fbXKi6efnz+
+        +CH8Mr0dfZ7e3gToTHOGnkuu02p+uuAZQ+OiyrKZ/+WRxt8rJjkj/T5iXTAZRHWQiSUvgNh2BMCM
+        fn4Vjq9GfTl/Xv7z7XMWP95P7qd3k/sPN0YCXVFN5aySGSip1qWKCHGNanzmRq0Uk7EoNCv0WSxy
+        UhGHf7+6mQCxlB5ip42GHVjJPccZA6ZIV2+q82xHgBvX9u/2XIgsE2vY7+rdOwTZmhnvWgQvlscg
+        YFYToVMGh2EaL2byXOk3yrEmNVZUaUSKgSgsgWTJ2yR5IwgywfBSE8lKYWnVXMWSl5qL4o3SeqZA
+        CbmkBd/QI1AwVSAYUW8UYU1gylYIuDfaOpualJKvaPxs3CFZzPgK3j2Gt2MMnH4uzZ79G+tvfM01
+        m9EkN5twQTPFXk4CO7ZGJ9twgl31qvje2eIJ2y5iEBU4E0zsyqctde8msy5st84O2nAO+HUPANsJ
+        5pj7E3seQDHWNcFfvwdibEw6F5JqcWh/7xPXw9Sk+68JBs1oPkC0NQcmFWKIB605MFypir0qLvdN
+        2VIUaUK/qPK5O5teE/D7wM4eOqlSfFkwNsBzW0RNmqNzLmkRp0OgDaEm7suuMF0OkGmsAZlnYj6A
+        guuLWERNVErdNaFnw5QZpiH0kJItBso0hC1Sy0FrbCUaxBaIO0pjuQdobAik9p7MaLGs6HIIc4sw
+        Bziu3iXdHMwp9u2TlgGgSZQkn1dDj7GWYlS6Kx37eogrW0iLtFnC/sRj79Q7uYadfJ7zQ3f2Pp4H
+        9IJ8MNTE5S7Y/H84vTgk1RBq0p647kD37OO96k/0RmN3BJ+HDwiDhkDqX0uqU3M6YaCSSna8YA8g
+        9ZwiBTo7O6tTRm1qmzM5aK86e4CojFOkccdrrBsC8pecapswL4zEBAl0JmgywKdbBHBu8Y7X6ey7
+        a14i+xsgzpp3eTkKTaVFMeQMbRldciE0X/D4NfXCvq3Vw9TvFS9idkKRAiNKNY854halmFk7pIxs
+        iG+cPaaAStwVCxlDCA/wtmSOUBNX2yWszMTzwLOmAzHbVTLUF8mMahQi41F4dTp6dxqG0/AiGoXR
+        ZPSAPlWZ/L/P+N00vI7OL32fslLpLmY8no5HUTiOwguDwdHpIxlfeBn4WWHerS5MpQ8zpdLW7LfW
+        KPrpg4Y3ijOE5M6+ee14q9077JAhRKYiZyUyCfdoofgGX+eTXkoQi6qAk89PgjXVyFVx/bZNTRoB
+        +6/POhWFYVI1cxs4iLSsTPWHllKKRxZr1W1rj4xOxzV/4j1Dk+hsSz5Xt3kBeNzJuZTCv924CtEf
+        cXiH8bWnKFnhBTXK8UiV8ZgVCtOtTREH/bi0Id4/Ot3fTX/5w/eAN8rkh3/QupuawOq/FPVfXjxY
+        EQ/sPIbFl9NP2ePDvxebh+ntJkCd7OrICBPpqMRjWuts6/mELWiV6ZlL8Y1YqrQtvksmczjbPHOY
+        qfgy3LndxHbjSXMAum+MimNErGfqe0URo/Z2abq5X2wTfGUSmf4vkpnbrW9TML1GOdz4FnPppmp+
+        qcKX/wCUNf3uJxQAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:56 GMT']
+      etag: [W/"c2b9a4b7ac55ebae82e3b17176bf4999"]
+      last-modified: ['Fri, 27 Jul 2018 19:36:40 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5795:D7C5FEA:5B5B7457']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4899']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.069867']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"has_wiki": false, "description": "", "allow_squash_merge":
+      true, "private": false, "has_issues": true, "allow_rebase_merge": true, "name":
+      "github-file", "allow_merge_commit": true, "has_projects": false, "homepage":
+      ""}'
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['222']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: PATCH
+    uri: https://api.github.com/repos/jacquerie/github-file
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WYXW/bNhSG/8qg2yWR5ThpIiDoCjQoMixtN3hbkRuDlmiLiSSqJGU3FvLf9/JD
+        luQVdmLeBArN8/Dl4SF5DpuApUEcTUYX19HkIjoJSp7SmW4L7j/err/kv+fJp+sN+fbXKimffnz+
+        +CH6Mr0dfZ7e3gToTAqKnkumsnp+umA5ReOizvOZ++WRJN9rKhgNh334uqQiiJsg50tWArHtCIAe
+        /fwqGl+NhnL+vPzn2+c8ebyf3E/vJvcfbrQEsiKKiFktclAypSoZh6FtlOMzO2otqUh4qWipzhJe
+        hHVo8e9XNxMglsJBzLTRsAOrmONYY8Bk2NebqSLfEWDHNf37PRc8z/ka9rt69w4Rbs20dw2Clctj
+        EDBrQq4yCodhGi968kyqN8oxJg1WVCpEioZILIGg6dskOSMI0sHw0oSCVtzQ6rlMBKsU4+UbpQ1M
+        geJiSUq2IUegYCpB0KLeKMKYwJSuEHBvtLU2TVgJtiLJs3aHoAllK3j3GN6OMXDqudJ79m+sv/Y1
+        U3RG0kJvwgXJJX05CczYCp1Mwwl21avie2eLp3S7iEFc4kzQsSuettS9m8y4sNs6O2jNOeDXPQBs
+        J5hj7k/02YOirZsQf90eSLAxyZwLovih/b1P3ADThP1/dTAoSgoP0cYcmIxzHw8ac2CYlDV9VVzu
+        m7KhyLAN/bIu5vZsek3A7wNbe+gkUrJlSamH57aIJmyPzrkgZZL5QFtCE9ovs8Jk6SFTWwMyz/nc
+        g4LrKzSIJpQZsdeEmvkp00xNGCAFXXjK1IQtUgmvNTYSNWILxB2lsNweGltC2DhP5qRc1mTpw9wi
+        9AGOq3dJNgdzin37pGMAqBMlwea17zHWUbRKe6VjX/u4soN0SJMl7E889k69l2uYyRcFO3Rn7+M5
+        wCDIvaE6LnfB+v/D6cUhqZrQhN2Jaw90xz7eq+5EbzX2R3B5uEcYtISw+bUiKtOnEwaqiKDHC3aA
+        sJkTpEBnZ2dNRolJbQsqvPaqtQeIiCRDGne8xqYlIH8piDIJ80JLTJFA55ykHj7dIoCzi3e8Tmvf
+        X/MK2Z+HOGPe5xUoNKXipc8Z2jH65JIrtmDJa+qFfVtrgGneS1Ym9IQgBUaUKpYwxC1KMb12SBmp
+        j2+sPaaAStwWCzlFCHt4W1BLaEJb26W0yvmz51nTg+jtKijqi3RGFAqR8Si6Oh29O42iaXQRj6J4
+        MnpAn7pK/99n/G4aXcfnl/HFpe5T1TLbxYzH0/EojsZxdKG74Oh0kYwvvAz8rDDvVxe60oeZlFln
+        9ltnFP/0QcMZJTlCcmffvHa81e4ddsgQIjNe0AqZhH20kGyDr/PJICVIeF3CyecnwZoo5Kq4frum
+        No2A/ddnlfFSM4mc2Q0cxErUuvpDSyX4I02U7EpCNHZnRq/nmj2xQS8tsLOzlZuTgOedggnB3euN
+        rRHdIYeXGFd98oqWTlKrHc9UOUtoKTHhRpdxmAGubch3z073d9Nf/nA94I8q/eGetO6mOrSGb0XD
+        txcHlqED9p7Dksvpp/zx4d+LzcP0dhOgUraVZIyJ9FTiOa1zt/F9ShekztXMJvlaLJHKlN8VFQXc
+        rR869FRcIW4dr6O7XQR9BNpvjIqDhK9n8ntNEKXmfmm72V9ME3ylU5nhL4Lq+21oU1K1RkHc+hZz
+        6Sdrbqmil/8A/oDZGSkUAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:56 GMT']
+      etag: [W/"67ac07ec321904a624e479ca4719af95"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF57E5:D7C6085:5B5B7458']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4898']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.099938']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"names": []}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.mercy-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['13']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: PUT
+    uri: https://api.github.com/repos/jacquerie/github-file/topics
+  response:
+    body: {string: !!python/unicode '{"names":[]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['12']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:56 GMT']
+      etag: ['"ea090b1b7f4cdcab6bd9de862e56f062"']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.mercy-preview; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5827:D7C611A:5B5B7458']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4897']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.089515']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: GET
+    uri: https://api.github.com/repos/jacquerie/github-file/labels?per_page=100
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA63VS4+bMBAA4L9iIVW9pMsjDza5rZTdPaWXpqrUqqocPAR3jU3toSSt9r93ICFs
+        NyvBAS7IM8jS5/EM3/56UnirMAjiYBmFQTTxtBHwow56m/XnxfbxQX79Uh0267vpZv103Gzvjt7E
+        K62iDzLEwq18nxfyZi8xK3c3icl9C4Vx/k+e/CrBSvBPqQ+pVOArvgPl/F25p100z4G2OS0So4yl
+        lYinfMYpKyDlpUJvhbaEeukSKwuURtNXn0wOmEm9Z9Lp98gqY59o5T1PXomWA0TzEUSiLJRMOELn
+        ehlqdUkqpiLu020z6QjmSmDGsqJUilmg03TIuLLAxZHBQTp0V94w6PfeVyN4QWdcJ5CDxk78f7A1
+        8wgA0j7zR6hYChxL26DP3mtgOAB4GAG4N0a8i4JUWof0bqrRSessa3KnOlGm5cbBPE57uY/NBgTV
+        UFHTgH2jltEA6hjdmIEqiFhxjSA6Yx1ml2DLC4LbRRz1VfP+gJYzjkj3gzqWDomgIGj71x0aTgco
+        /4xQUKl/c0WD7TJ3ukBrgxksFss+W9OdwkAzeBxAzqzcZ3gtmw2QBSPImslQz8UL7UXkMldv4wVM
+        +2wPpcUMLJOa7mbO29qdu/Gt8s0HIMMRkJXRmMq6s8+/jS7QEtPm6SM25askzVRtkO2g+XeAYHR+
+        z9//AWoPTYURBwAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:57 GMT']
+      etag: [W/"0d5ddd4787e9b6fd410dc6ce12e4d8c3"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5867:D7C618C:5B5B7458']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4896']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.047008']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/bug
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:57 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF588F:D7C61F8:5B5B7459']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4895']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.077540']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/duplicate
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:57 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF58CF:D7C6275:5B5B7459']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4894']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.082336']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/enhancement
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:57 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5906:D7C62EF:5B5B7459']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4893']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.065218']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:58 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5939:D7C6358:5B5B7459']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4892']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.076328']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:58 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF597B:D7C63BB:5B5B745A']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4891']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.062473']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/invalid
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:58 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF59B4:D7C6430:5B5B745A']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4890']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.083052']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/question
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:58 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF59F1:D7C64A9:5B5B745A']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4889']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.081516']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/wontfix
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:59 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5A2C:D7C6531:5B5B745A']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4888']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.115347']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{"color": "d73a4a", "name": "bug", "description": "Something
+      isn''t working"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['76']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092284,"node_id":"MDU6TGFiZWwxMDA3MDkyMjg0","url":"https://api.github.com/repos/jacquerie/github-file/labels/bug","name":"bug","color":"d73a4a","default":true,"description":"Something
+        isn''t working"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['209']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:59 GMT']
+      etag: ['"148203004f66087d9460f232285ca859"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/bug']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5A6B:D7C65C2:5B5B745B']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4887']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.060625']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "cfd3d7", "name": "duplicate", "description":
+      "This issue or pull request already exists"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092289,"node_id":"MDU6TGFiZWwxMDA3MDkyMjg5","url":"https://api.github.com/repos/jacquerie/github-file/labels/duplicate","name":"duplicate","color":"cfd3d7","default":true,"description":"This
+        issue or pull request already exists"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['239']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:59 GMT']
+      etag: ['"304ab42f5ec6c5bdaec76ee66e4547ea"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/duplicate']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5AAE:D7C6623:5B5B745B']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4886']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.060088']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "a2eeef", "name": "enhancement", "description":
+      "New feature or request"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['83']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092294,"node_id":"MDU6TGFiZWwxMDA3MDkyMjk0","url":"https://api.github.com/repos/jacquerie/github-file/labels/enhancement","name":"enhancement","color":"a2eeef","default":true,"description":"New
+        feature or request"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['224']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:00 GMT']
+      etag: ['"dc4e2462cdfbfcdd560fcf7fd0f7973c"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/enhancement']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5B00:D7C66AA:5B5B745B']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4885']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.081802']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "7057ff", "name": "good first issue", "description":
+      "Good for newcomers"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['84']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092295,"node_id":"MDU6TGFiZWwxMDA3MDkyMjk1","url":"https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue","name":"good
+        first issue","color":"7057ff","default":true,"description":"Good for newcomers"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['234']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:00 GMT']
+      etag: ['"6d81208088c9d336ea2729d74dfaadea"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5B57:D7C6767:5B5B745C']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4884']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.049696']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "008672", "name": "help wanted", "description":
+      "Extra attention is needed"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['86']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092299,"node_id":"MDU6TGFiZWwxMDA3MDkyMjk5","url":"https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted","name":"help
+        wanted","color":"008672","default":true,"description":"Extra attention is
+        needed"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['229']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:00 GMT']
+      etag: ['"542a3c7b917050f351df78f87e759541"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5BB3:D7C67F7:5B5B745C']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4883']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.066011']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "e4e669", "name": "invalid", "description":
+      "This doesn''t seem right"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['80']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092305,"node_id":"MDU6TGFiZWwxMDA3MDkyMzA1","url":"https://api.github.com/repos/jacquerie/github-file/labels/invalid","name":"invalid","color":"e4e669","default":true,"description":"This
+        doesn''t seem right"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['217']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:00 GMT']
+      etag: ['"7293d41c8661a0bf6289288bf6b9f40f"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/invalid']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5C29:D7C68C2:5B5B745C']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4882']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.056291']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "d876e3", "name": "question", "description":
+      "Further information is requested"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['90']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092306,"node_id":"MDU6TGFiZWwxMDA3MDkyMzA2","url":"https://api.github.com/repos/jacquerie/github-file/labels/question","name":"question","color":"d876e3","default":true,"description":"Further
+        information is requested"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['228']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:01 GMT']
+      etag: ['"adcc976d2995a6de60d8a3b0a752c5c5"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/question']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5CB8:D7C69C4:5B5B745C']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4881']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.064390']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "ffffff", "name": "wontfix", "description":
+      "This will not be worked on"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['83']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092307,"node_id":"MDU6TGFiZWwxMDA3MDkyMzA3","url":"https://api.github.com/repos/jacquerie/github-file/labels/wontfix","name":"wontfix","color":"ffffff","default":true,"description":"This
+        will not be worked on"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['220']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:37:01 GMT']
+      etag: ['"5096d197e6318df4b006395042efc827"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/wontfix']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCEA:5CB0:6FF5D27:D7C6B07:5B5B745D']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4880']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.084544']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+version: 1

--- a/tests/cassettes/test_update_can_set_the_description.yaml
+++ b/tests/cassettes/test_update_can_set_the_description.yaml
@@ -1,0 +1,878 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: GET
+    uri: https://api.github.com/repos/jacquerie/github-file
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WYXW/bNhSG/8qg2yWR5ThtIiDoCjQoMixpN3hbkRuDlmiLiSSqJGU3FvLf9/JD
+        luQVdmLeBA7F8/Dl4SF5DpuApUEcTUYXV9HkIjoJSp7SmW4L7j7drL/kv+fJ56sN+fbXKimfftx/
+        +hh9md6M7qc31wE6k4Ki55KprJ6fLlhO0bio83zmvjyS5HtNBaPhsA9fl1QEcRPkfMlKILYdAdCj
+        n19G48vRUM6f7/75dp8nj3eTu+nt5O7jtZZAVkQRMatFDkqmVCXjMLSNcnxmR60lFQkvFS3VWcKL
+        sA4t/sPqegLEUjiImTYadmAVcxxrDJgM+3ozVeQ7Auy4pn+/54LnOV/Dflfv3iHCrZn2rkGwcnkM
+        AmZNyFVG4TBM40VPnkn1RjnGpMGKSoVI0RCJJRA0fZskZwRBOhhemlDQihtaPZeJYJVivHyjtIEp
+        UFwsSck25AgUTCUIWtQbRRgTmNIVAu6NttamCSvBViR51u4QNKFsBe8ew9sxBk49V3rP/o31175m
+        is5IWuhNuCC5pC8ngRlboZNpOMGuelV872zxlG4XMYhLnAk6dsXTlrp3kxkXdltnB605B/y6B4Dt
+        BHPM/Yk+e1C0dRPir9sDCTYmmXNBFD+0v/eJG2CasP+vDgZFSeEh2pgDk3Hu40FjDgyTsqavist9
+        UzYUGbahX9bF3J5Nrwn4fWBrD51ESrYsKfXw3BbRhO3RORekTDIfaEtoQvvLrDBZesjU1oDMcz73
+        oOD6Cg2iCWVG7DWhZn7KNFMTBkhBF54yNWGLVMJrjY1EjdgCcUcpLLeHxpYQNs6TOSmXNVn6MLcI
+        fYDj6l2SzcGcYt8+6RgA6kRJsHnte4x1FK3SXunY1z6u7CAd0mQJ+xOPvVPv5Rpm8kXBDt3Z+3gO
+        MAhyb6iOy12w/v9wenFIqiY0YXfi2gPdsY/3qjvRW439EVwe7hEGLSFsfq2IyvTphIEqIujxgh0g
+        bOYEKdDZ2VmTUWJS24IKr71q7QEiIsmQxh2vsWkJyF8KokzCvNASUyTQOSeph0+3CODs4h2v09r3
+        17xC9uchzpj3eQUKTal46XOGdow+ueSKLVjymnph39YaYJoPkpUJPSFIgRGliiUMcYtSTK8dUkbq
+        4xtrjymgErfFQk4Rwh7eFtQSmtDWdimtcv7sedb0IHq7Cor6Ip0RhUJkPIouT0fvT6NoGl3Eoyie
+        jB7Qp67S//cZv59GV/H5RRyNdZ+qltkuZjyejkf4HkcXuguOThfJ+IWXgZ8V5v3qQlf6MJMy68x+
+        64zinz5oOKMkR0ju7JvXjrfavcMOGUJkxgtaIZOwjxaSbfDrfDJICRJel3Dy+UmwJgq5Kq7frqlN
+        I2D/9VllvNRMImd2AwexErWu/tBSCf5IEyX7bd2R0eu4Zk9sYKgTnW3JZ+s2JwCPOwUTgru3G1sh
+        uiMO7zCu9uQVLZ2gVjkeqXKW0FJiuo0u4qAflzbEu0enu9vpL3+4HvBGlf5wD1q3Ux1Yw5ei4cuL
+        A8vQAXuPYcm76ef88eHfi83D9GYToE62dWSMifRU4jGtc7bxfEoXpM7VzKb4WiyRyhTfFRUFnK2f
+        OfRUXBlu3a5ju/WkPgDtb4yKY4SvZ/J7TRCj5nZpu9kvpgm+0onM8Iug+nYb2pRUrVEOt77FXPqp
+        mluq6OU/prlk5ScUAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:48 GMT']
+      etag: [W/"9220254d791c1104a58019e8dbb48fd9"]
+      last-modified: ['Fri, 27 Jul 2018 19:35:12 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BF772:B8581AB:5B5B7413']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4979']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.079275']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"has_wiki": true, "description": "Configure your GitHub
+      repository from a file, without having to click around in the UI.", "allow_squash_merge":
+      true, "private": false, "has_issues": true, "allow_rebase_merge": true, "name":
+      "github-file", "allow_merge_commit": true, "has_projects": true, "homepage":
+      ""}'
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['307']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: PATCH
+    uri: https://api.github.com/repos/jacquerie/github-file
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WYYXPiNhCG/4qHryUYE7hLPJO53vQy13SaXNvh2pt8YYQtsBLb8kkyHHjy3/tK
+        ssGmHUjQFwaM9tGr1a68q6rH4l4YjIeT62A8Cfq9nMd0pp/17j/drr+kv6XR5+st+fbXKsqffzx8
+        +hh8md4OH6a3Nz0MJhnFyCVTSTm/WLCU4uGiTNNZ/c8Tib6XVDDqd8fwdU5FL6x6KV+yHIjdQAD0
+        7JdXwehq2JXz57u/vz2k0dP9+H56N77/eKMlkBVRRMxKkYKSKFXI0PftQzka2FlLSUXEc0VzNYh4
+        5pe+xX9Y3YyBWIoaYpaNBwewgtUcawyY9Nt6E5WlBwLsvGZ8e+SCpylfw/5Q79Ep/J2Z9q5BsHx5
+        DgJmlc9VQuEwLONFL55J9UY5xqTCjkqFSNEQiS0QNH6bpNoIgnQwvFS+oAU3tHIuI8EKxXj+Rmkd
+        U6C4WJKcbckZKJhKELSoN4owJjClKwTcG22tTeUXgq1ItNHuEDSibAXvnsM7MAZObQqds1+x/9rX
+        TNEZiTOdhAuSSvrS75m5FQaZB31k1avi+yDFY7rbREz3C88XbFkK6m14KbzPTP1azj3jKaa42HgL
+        wTOPePoM6XtrHCi8VF5CVghZT3EvSln07BHByzz2WO4hhr2vdwOsYMHF807q0cw1s+3z8UCv5pzY
+        rCMA5CjMIeeZbhwo2rry8VknVoRsJ3MuCHzkgO1gKr/9U0eYoiRzoBtzYBLOXTxozIFhUpb0VcF+
+        bD8MRfpNPuVlNrcH3muy6BjY2kMnkZItc0odPLdDVH5zHs8FyaPEBdoQKt9+MztMlg4ytTUg85TP
+        HSh4J/oGUfkyIfbdo2ZuyjRTEzpIQReOMjVhh1TCaY+NRI3YAfHiU9huB40Nwa9qT6YkX5Zk6cLc
+        IbDT+tW8JNuThcqxPNkzANTVl2Dz0vUY21O0SlsnIK9dXLmH7JGm9DhezRxdequAMYvPMnaqEDjG
+        qwGdIHeG6rg8BOvfp2uWU1I1ofL3J6490Gv2+V6tT/RGY3uGurh3CIOG4Fc/FUQl+nTCRAUR9HzB
+        NcCv5gR11WAwqBJKTL2cUeGUq9YeICKiBLXh+RqrhoD6JSPKVOELLTFGVZ5yEjv4dIcAzm7e+Tqt
+        fXvPC7SZDuKMeZuXofKUiucuZ+ie0SbnXLEFi17ThBxLrQ6m+iBZHtE+SdM+olSxiCFuUSzrvUPJ
+        SF18Y+2xBLT3tgNJKULYwduCWkLl24YxpkXKN45nTQui01VQNC3xjCi0G6NhcHUxfH8RBNNgEg6D
+        cDx8xJiyiP87ZvR+GlyHl5NwfKXHFKVMDjGj0XQ0DINRGEz0EByddSTjG64b8In7j2633+4u9PUB
+        zKRM9mY/743C/70lqY2iFCF5kDevnW91+A47ZQiRCc9ogUrC3oRItsW3y3GnJIjQhMHJl/3emijU
+        qnj97h81ZQTs/9igi8s1k8iZTeBeqESpW0o8KQR/opGS7Wf7I6M1cM2eWcdQFzq7ls/2bbUA3Bhl
+        TAheXwjlSPLdIYnLnbqh5QXNa0GNctx8ocOkucRyK93EQT9e2hBf32Td30293+sR8EYR/6hvye6m
+        OrC610/d65waLP0a2Lphi95NP6dPj/9Mto/T220PzbftI0MspKUSN3R7ZxvPx3RBylTNbImvxRKp
+        TEdfUJHB2fruRC+l7u2t23VsN57UB6D9jllxjPD1TH4vCWLUvF2aYfYf8wi+0oVM9x9B9duta5NT
+        tUY73PgWa2mXavVWBS//AmqFFth8FAAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:48 GMT']
+      etag: [W/"a2ac75af06895c1a07e161309d854b31"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BF7CB:B858225:5B5B7414']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4978']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.110780']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"names": []}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.mercy-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['13']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: PUT
+    uri: https://api.github.com/repos/jacquerie/github-file/topics
+  response:
+    body: {string: !!python/unicode '{"names":[]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['12']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:48 GMT']
+      etag: ['"ea090b1b7f4cdcab6bd9de862e56f062"']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.mercy-preview; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BF817:B8582E1:5B5B7414']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4977']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.070797']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: GET
+    uri: https://api.github.com/repos/jacquerie/github-file/labels?per_page=100
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62VUW+bMBDHv4qFNO0lKyTpIMnbpKx9yl7WaVqnaXLwAS7GZvYxMk397jtICF0z
+        FaTBC7o766yf//6fv/72pPA28yCIgvV8EYYzTxsB35ukt9t+Cu9ub+T95/qw275b7rb5YffwZeHN
+        vMoqWpAhlm7j+7yUV6nErNpfxabwLZTG+Q88/lGBleAfS28SqcBXfA/K+fsqpS6aF0BtjkFslLEU
+        iWjJrzlVBSS8Uuht0FbQhC62skRpNK36aArATOqUSadfI6uNzSnyHmfPiKIRRMsJiERVKhlzhJ7r
+        aaqjixOxFNEQ3V0mHYG5CpixrKyUYhboNB0yrixw8YvBQTp0F7zRCAXjKRQEnXEdQwEae+K/kx0z
+        XwBAMsT8AWqWAMfKttAn3kvAEYLGUwiaGiNeLYJEWof0b9XoSZsqa2tHnajS4UbB2ygZxL1tGxCo
+        hppMA/ZSy9UILdMptMxAlYRYc40gesYmzc7JDi8IVmHU7PqiP98f0HLGEel+kGPpkAgUBLV/7tD1
+        fNih+YH2+9+ZI/VPrmiwnedOn+jY4BrCcD3E1rpTGGgHjwMomJVphpdkI/TLp9CvnQzNXDyjPcmc
+        5+oqCqExxou63VQWM7BMarqbBe+0O7nxX/KN8GM+hR9rozGRzUU4PRt9okNM2m8IsZWvljRTtUG2
+        h/btAMHo/B6//QHaDC0/EQcAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:49 GMT']
+      etag: [W/"5237c59fbac3984882198e7e0a2e23f0"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BF857:B858347:5B5B7414']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4976']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.058959']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/bug
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:35:49 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BF8A3:B8583BE:5B5B7415']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4975']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.079675']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/duplicate
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:35:49 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BF8FC:B85845E:5B5B7415']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4974']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.079470']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/enhancement
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:35:50 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BF952:B8584E9:5B5B7415']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4973']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.082041']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:35:50 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BF9B4:B858597:5B5B7416']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4972']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.080136']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:35:50 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BF9FE:B858638:5B5B7416']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4971']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.082126']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/invalid
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:35:51 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BFA5F:B8586C4:5B5B7416']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4970']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.078363']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/question
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:35:51 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BFACA:B858771:5B5B7417']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4969']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.075943']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/wontfix
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:35:51 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BFB1D:B858836:5B5B7417']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4968']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.062152']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{"color": "d73a4a", "name": "bug", "description": "Something
+      isn''t working"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['76']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007091650,"node_id":"MDU6TGFiZWwxMDA3MDkxNjUw","url":"https://api.github.com/repos/jacquerie/github-file/labels/bug","name":"bug","color":"d73a4a","default":true,"description":"Something
+        isn''t working"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['209']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:52 GMT']
+      etag: ['"b637280b66a826e23c30978be2aef473"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/bug']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BFB5E:B8588BC:5B5B7417']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4967']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.069209']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "cfd3d7", "name": "duplicate", "description":
+      "This issue or pull request already exists"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007091651,"node_id":"MDU6TGFiZWwxMDA3MDkxNjUx","url":"https://api.github.com/repos/jacquerie/github-file/labels/duplicate","name":"duplicate","color":"cfd3d7","default":true,"description":"This
+        issue or pull request already exists"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['239']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:52 GMT']
+      etag: ['"fb34db1b5449a5604dc2bce9a0d9e774"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/duplicate']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BFBA4:B858937:5B5B7418']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4966']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.051583']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "a2eeef", "name": "enhancement", "description":
+      "New feature or request"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['83']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007091652,"node_id":"MDU6TGFiZWwxMDA3MDkxNjUy","url":"https://api.github.com/repos/jacquerie/github-file/labels/enhancement","name":"enhancement","color":"a2eeef","default":true,"description":"New
+        feature or request"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['224']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:52 GMT']
+      etag: ['"a1947659ba72b88d6febb5803de94de9"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/enhancement']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BFBEA:B85899A:5B5B7418']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4965']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.066110']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "7057ff", "name": "good first issue", "description":
+      "Good for newcomers"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['84']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007091653,"node_id":"MDU6TGFiZWwxMDA3MDkxNjUz","url":"https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue","name":"good
+        first issue","color":"7057ff","default":true,"description":"Good for newcomers"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['234']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:52 GMT']
+      etag: ['"96e9df1747dae3526d0dc1b5de4a9c96"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BFC2C:B858A45:5B5B7418']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4964']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.068919']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "008672", "name": "help wanted", "description":
+      "Extra attention is needed"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['86']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007091654,"node_id":"MDU6TGFiZWwxMDA3MDkxNjU0","url":"https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted","name":"help
+        wanted","color":"008672","default":true,"description":"Extra attention is
+        needed"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['229']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:53 GMT']
+      etag: ['"242b90c52fb798b1ec909462a4cc1320"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BFC88:B858AC3:5B5B7418']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4963']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.066504']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "e4e669", "name": "invalid", "description":
+      "This doesn''t seem right"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['80']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007091663,"node_id":"MDU6TGFiZWwxMDA3MDkxNjYz","url":"https://api.github.com/repos/jacquerie/github-file/labels/invalid","name":"invalid","color":"e4e669","default":true,"description":"This
+        doesn''t seem right"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['217']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:53 GMT']
+      etag: ['"0225339a562482af9fad80fe5ba51f5d"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/invalid']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BFCD2:B858B68:5B5B7419']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4962']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.069428']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "d876e3", "name": "question", "description":
+      "Further information is requested"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['90']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007091664,"node_id":"MDU6TGFiZWwxMDA3MDkxNjY0","url":"https://api.github.com/repos/jacquerie/github-file/labels/question","name":"question","color":"d876e3","default":true,"description":"Further
+        information is requested"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['228']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:53 GMT']
+      etag: ['"a5eb18a1dea706b382e63c97ef2249a5"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/question']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BFD1E:B858BDD:5B5B7419']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4961']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.056803']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "ffffff", "name": "wontfix", "description":
+      "This will not be worked on"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['83']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007091668,"node_id":"MDU6TGFiZWwxMDA3MDkxNjY4","url":"https://api.github.com/repos/jacquerie/github-file/labels/wontfix","name":"wontfix","color":"ffffff","default":true,"description":"This
+        will not be worked on"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['220']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:35:53 GMT']
+      etag: ['"a6407ec44aaabfa357cca12947cb56cf"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/wontfix']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['DCE2:5CB5:57BFD56:B858C53:5B5B7419']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4960']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.066657']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+version: 1

--- a/tests/cassettes/test_update_can_set_the_topics.yaml
+++ b/tests/cassettes/test_update_can_set_the_topics.yaml
@@ -14,30 +14,29 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6WYb2/bNhDGv4rgt3Miy3Ha1EDQFWvQZVjSbnC3Im8MWqItJhKpkpRdW8h338M/
-        smR3sBPrjWHLvB8fHu+oO1Y9lvTG0Whw+S4aXUb9HhcJnZpnvbuPN6vP2R9Z/Ondhnz7exnzpx/3
-        Hz9Enyc3g/vJzXUPg0lOMXLBdFrOzuYso3g4L7Ns6v95JPH3kkpGw90xYsWp7I2rXiYWjAOxHQiA
-        mf3iKhpeDXbl/PXmn2/3Wfx4N7qb3I7uPlwbCWRJNJHTUmagpFoXahyG7qEanrtZS0VlLLimXJ/H
-        Ig/L0OHfL69HQCykh9hl48EerGCe44wBU2Fbb6rzbE+Am9eOb4+ciywTK9jv6z04Rbg1M961CMYX
-        pyBgVoVCpxQOwzKezeKZ0q+UY00q7KjSiBQDUdgCSZPXSfJGEGSC4bkKJS2EpZUzFUtWaCb4K6Xt
-        mAIl5IJwtiEnoGCqQDCiXinCmsCULhFwr7R1NlVYSLYk8dq4Q9KYsiW8ewpvzxg4vS5Mzn7F/htf
-        M02nJMlNEs5Jpuhzv2fn1hhkH/SRVS+K770UT+h2EzHdb4LP2aKUNFiLUgafmP69nAXWU0wLuQ7m
-        UuQBCcwZ0g9WOFBEqYOULBGygRZBnLH4KSBSlDwJGA8Qw8HX23OsYC7k01bqwcy1szX5uKfXcI5s
-        1gEAchTmkPNE1x0oxroK8ekTK0a2k5mQBD7qgN3BVGH7p4kwTUnegW7NgUmF6OJBaw4MU6qkLwr2
-        Q/thKSqs84mX+cwdeC/JokNgZw+dRCm24JR28NwWUYX1eTyThMdpF2hNqEL3ze4wWXSQaawBmWVi
-        1oGCd2JoEVWoUuLePXraTZlhGsIOUtJ5R5mGsEVq2WmPrUSD2ALx4tPY7g4aa0JYeU9mhC9KsujC
-        3CKw0+bVvCCbo4XKoTxpGACa6kuyWdn1GGsoRqWrE5DXXVzZQBqkLT0OVzMHl94qYOzi85wdKwQO
-        8TxgJ8g7Q01c7oPN7+M1yzGphlCFzYnrDnTPPt2r/kSvNbZn8MV9hzCoCWH1S0F0ak4nTFQQSU8X
-        7AFhNSOoq87Pz6uUElsv51R2ylVnDxCRcYra8HSNVU1A/ZITbavwuZGYoCrPBEk6+HSLAM5t3uk6
-        nX17zwu0mR3EWfM2L0flqbTgXc7QhtEmc6HZnMUvaUIOpdYOpnqvGI9pn2RZH1GqWcwQtyiWzd6h
-        ZKRdfOPssQS0964DyShCuIO3JXWEKnQNY0KLTKw7njUtiElXSdG0JFOi0W4MB9HV2eDtWRRNosvx
-        IBqPBg8YUxbJz2OG0QQDhhh2YcYUpUp/wlxNBm/HF4NxNDRDcHT6SMY3XDfgE/cfu91+u7sw1wcw
-        UyptzH5tjMb/e0vijeIMIbmXNy+db7n/DjtmCJGpyGmBSsLdhCi2wbcL3Au1SoIYTRicfNHvrYhG
-        rYrXb/OoLiNg/2WNLo4bJlFTl8C9sZalaSnxpJDikcZaNX0mHjZnRmvkij2xnVFGYGPnOjcvAXdG
-        OZNS+CshjjTfHpO43vEtrSgo95Jq7VgjekzKFRZcmTYOK8BrG/L9Xdbd7ST404+AP4rkh78nu52Y
-        0Nq9gNq90PFgFXpg644tfjP5lD0+/Hu5eZjcbHpov10nOcZCWipxR9e42/o+oXNSZnrqinwjliht
-        e/qCyhzuNrcnZim+u3eON9Fdb4I5At13zIqDRKym6ntJEKX2/bJ1lvvLPoOzTC2z95ek5g1XW7mJ
-        ONUrtMS1d7GadrnmNyt6/g9rgnKJgBQAAA==
+        H4sIAAAAAAAAA6WYXW/bNhSG/8qg2yWh5ThpIiDoCjQoMixtN3hbkRuDlmiLiSSqJGU3FvLf9/JD
+        luQVdmLdBArN8/Dl4SF5DuuAJ0EUTkYX1+HkIjwJCpGwmWkL7j/err9kv2fxp+sN/fbXKi6efnz+
+        +CH8Mr0dfZ7e3gToTHOGnkuu02p+uuAZQ+OiyrKZ/+WRxt8rJjkj/T5iXTAZRHWQiSUvgNh2BMCM
+        fn4Vjq9GfTl/Xv7z7XMWP95P7qd3k/sPN0YCXVFN5aySGSip1qWKCHGNanzmRq0Uk7EoNCv0WSxy
+        UhGHf7+6mQCxlB5ip42GHVjJPccZA6ZIV2+q82xHgBvX9u/2XIgsE2vY7+rdOwTZmhnvWgQvlscg
+        YFYToVMGh2EaL2byXOk3yrEmNVZUaUSKgSgsgWTJ2yR5IwgywfBSE8lKYWnVXMWSl5qL4o3SeqZA
+        CbmkBd/QI1AwVSAYUW8UYU1gylYIuDfaOpualJKvaPxs3CFZzPgK3j2Gt2MMnH4uzZ79G+tvfM01
+        m9EkN5twQTPFXk4CO7ZGJ9twgl31qvje2eIJ2y5iEBU4E0zsyqctde8msy5st84O2nAO+HUPANsJ
+        5pj7E3seQDHWNcFfvwdibEw6F5JqcWh/7xPXw9Sk+68JBs1oPkC0NQcmFWKIB605MFypir0qLvdN
+        2VIUaUK/qPK5O5teE/D7wM4eOqlSfFkwNsBzW0RNmqNzLmkRp0OgDaEm7suuMF0OkGmsAZlnYj6A
+        guuLWERNVErdNaFnw5QZpiH0kJItBso0hC1Sy0FrbCUaxBaIO0pjuQdobAik9p7MaLGs6HIIc4sw
+        Bziu3iXdHMwp9u2TlgGgSZQkn1dDj7GWYlS6Kx37eogrW0iLtFnC/sRj79Q7uYadfJ7zQ3f2Pp4H
+        9IJ8MNTE5S7Y/H84vTgk1RBq0p647kD37OO96k/0RmN3BJ+HDwiDhkDqX0uqU3M6YaCSSna8YA8g
+        9ZwiBTo7O6tTRm1qmzM5aK86e4CojFOkccdrrBsC8pecapswL4zEBAl0JmgywKdbBHBu8Y7X6ey7
+        a14i+xsgzpp3eTkKTaVFMeQMbRldciE0X/D4NfXCvq3Vw9TvFS9idkKRAiNKNY854halmFk7pIxs
+        iG+cPaaAStwVCxlDCA/wtmSOUBNX2yWszMTzwLOmAzHbVTLUF8mMahQi41F4dTp6dxqG0/AiGoXR
+        ZPSAPlWZ/L/P+N00vI7OL6MwNH3KSqW7mPF4Oh5F4TgKL0wXHJ0+kvGFl4GfFebd6sJU+jBTKm3N
+        fmuNop8+aHijOENI7uyb14632r3DDhlCZCpyViKTcI8Wim/wdT7ppQSxqAo4+fwkWFONXBXXb9vU
+        pBGw//qsU1EYJlUzt4GDSMvKVH9oKaV4ZLFW3bb2yOh0XPMn3jM0ic625HN1mxeAx52cSyn8242r
+        EP0Rh3cYX3uKkhVeUKMcj1QZj1mhMN3aFHHQj0sb4v2j0/3d9Jc/fA94o0x++Aetu6kJrP5LUf/l
+        xYMV8cDOY1h8Of2UPT78e7F5mN5uAtTJro6MMJGOSjymtc62nk/YglaZnrkU34ilStviu2Qyh7PN
+        M4eZii/DndtNbDeeNAeg+8aoOEbEeqa+VxQxam+Xppv7xTbBVyaR6f8imbnd+jYF02uUw41vMZdu
+        quaXKnz5D5tXrmInFAAA
     headers:
       access-control-allow-origin: ['*']
       access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
@@ -47,9 +46,9 @@ interactions:
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:25:57 GMT']
-      etag: [W/"3cc92b01e5ab9b3c21ab9210f28a67b9"]
-      last-modified: ['Sat, 21 Jul 2018 01:25:03 GMT']
+      date: ['Fri, 27 Jul 2018 19:36:29 GMT']
+      etag: [W/"8b6bd887b1c1c575ea70f2a5ad265f7b"]
+      last-modified: ['Fri, 27 Jul 2018 19:36:11 GMT']
       referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       server: [GitHub.com]
       status: [200 OK]
@@ -58,18 +57,17 @@ interactions:
       x-content-type-options: [nosniff]
       x-frame-options: [deny]
       x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['9BD0:413C:FA8A38:1CB9BE8:5B528BA4']
+      x-github-request-id: ['EBEC:5CB5:57C20FD:B85D760:5B5B743D']
       x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4976']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.068907']
+      x-ratelimit-remaining: ['4939']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.077430']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"has_wiki": false, "description": "Configure your GitHub
-      repository from a file, without having to click around in the UI.", "allow_squash_merge":
-      false, "private": false, "has_issues": true, "allow_rebase_merge": true, "name":
-      "github-file", "allow_merge_commit": false, "has_projects": false, "homepage":
+    body: !!python/unicode '{"has_wiki": true, "description": "", "allow_squash_merge":
+      true, "private": false, "has_issues": true, "allow_rebase_merge": true, "name":
+      "github-file", "allow_merge_commit": true, "has_projects": true, "homepage":
       ""}'
     headers:
       Accept: [application/vnd.github.v3.full+json]
@@ -77,7 +75,7 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
       Connection: [keep-alive]
-      Content-Length: ['311']
+      Content-Length: ['220']
       Content-Type: [application/json]
       User-Agent: [github3.py/1.1.0]
     method: PATCH
@@ -85,30 +83,29 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6WYb2/iOBDGv0rE26OEULrtIlV7q9uq19O1u3di71Z9g0xiiNskztoOLET97vf4
-        DySwJ2jxGwTB8/Pj8Ywz47rDks4oGvYv3kfDi6jbKXhCJ/pZ5/7TzfJz9kcW375fk29/L+Li+cfD
-        p4/R5/FN/2F8c93BYJJTjJwzlVbTsxnLKB7OqiybuH+eSPy9ooLRcHcMXxZUdEZ1J+NzVgCxHQiA
-        nv38Khpc9Xfl/PXun28PWfx0P7wf3w3vP15rCWRBFBGTSmSgpEqVchSG9qEc9OyslaQi5oWiherF
-        PA+r0OI/LK6HQMyFg5hl48EerGSOY40Bk2Fbb6rybE+AndeMb4+c8SzjS9jv6z04Rbg10941CFbM
-        T0HArA65SikchmW86MUzqd4ox5jU2FGpECkaIrEFgiZvk+SMIEgHw0sdClpyQ6umMhasVIwXb5S2
-        YwoUF3NSsDU5AQVTCYIW9UYRxgSmdIGAe6OttanDUrAFiVfaHYLGlC3g3VN4e8bAqVWpc/Yr9l/7
-        mik6IUmuk3BGMklfuh0zt8Ig86CLrHpVfO+leEK3m4jpfuPFjM0rQYMVr0Rwy9Tv1TQwnmKKi1Uw
-        EzwPSKDPkG6wxIHCKxWkZIGQDRQP4ozFzwERvCqSgBUBYjj4etfDCmZcPG+lHsxcM1uTj3t6NefI
-        Zh0AIEdhDjnPdOVB0dZ1iE+XWDGynUy5IPCRB3YHU4ftnzrCFCW5B92YA5Ny7uNBYw4Mk7Kirwr2
-        Q/thKDLc5FNR5VN74L0miw6BrT10EinZvKDUw3NbRB1uzuOpIEWc+kA3hDq038wOk7mHTG0NyDTj
-        Uw8K3omhQdShTIl996iJnzLN1IQdpKAzT5masEUq4bXHRqJGbIF48Slst4fGDSGsnSczUswrMvdh
-        bhHYaf1qnpP10ULlUJ40DAB19SXYtPI9xhqKVmnrBOS1jysbSIM0pcfhaubg0lsFjFl8nrNjhcAh
-        ngPsBLk3VMflPlj/Pl6zHJOqCXXYnLj2QHfs073qTvSNxvYMrrj3CIMNIax/KYlK9emEiUoi6OmC
-        HSCspwR1Va/Xq1NKTL2cU+GVq9YeICLiFLXh6RrrDQH1S06UqcJnWmKCqjzjJPHw6RYBnN2803Va
-        +/ael2gzPcQZ8zYvR+UpFS98ztCG0SYXXLEZi1/ThBxKrR1M/UGyIqZdkmVdRKliMUPcoljWe4eS
-        kfr4xtpjCWjvbQeSUYSwh7cFtYQ6tA1jQsuMrzzPmhZEp6ugaFqSCVFoNwb96Oqsf3kWRePoYtSP
-        RsP+I8ZUZfLzmEE0xoDBxejiUo8pK5n+hLka9y9H5/1RNNBDcHS6SMY3XDfgE/cfu91+u7vQ1wcw
-        kzJtzH5tjEb/e0vijOIMIbmXN6+db7H/DjtmCJEpz2mJSsLehEi2xrdz3Au1SoIYTRicfN7tLIlC
-        rYrXb/NoU0bA/ssKXVyhmURObAJ3RkpUuqXEk1LwJxor2fSZeNicGa2RS/bMdkZpgY2d7dycBNwZ
-        5UwI7q6ECqT59pjE9Y5raXlJCydpox1rRI9JC4kF17qNwwrw2oZ8d5d1fzcO/nQj4I8y+eHuye7G
-        OrR2L6B2L3QcWIYO2Lpji9+Nb7Onx38v1o/jm3UH7bftJEdYSEsl7ugadxvfJ3RGqkxNbJGvxRKp
-        TE9fUpHD3fr2RC/FdffW8Tq6N5ugj0D7HbPiIOHLifxeEUSpeb9snWX/Ms/gLF3L7P0lqH7Dbazs
-        RAVVS7TEG+9iNe1yzW1W9PIf4wrn54AUAAA=
+        H4sIAAAAAAAAA6WYXW/bNhSG/8qg2yWR5ThpIiDoCjQoMixtN3hbkRuDlmiLiSSqJGU3FvLf9/JD
+        luQVdmLeBArN8/Dl4SF5DpuApUEcTUYX19HkIjoJSp7SmW4L7j/err/kv+fJp+sN+fbXKimffnz+
+        +CH6Mr0dfZ7e3gToTAqKnkumsnp+umA5ReOizvOZ++WRJN9rKhgNh334uqQiiJsg50tWArHtCIAe
+        /fwqGl+NhnL+vPzn2+c8ebyf3E/vJvcfbrQEsiKKiFktclAypSoZh6FtlOMzO2otqUh4qWipzhJe
+        hHVo8e9XNxMglsJBzLTRsAOrmONYY8Bk2NebqSLfEWDHNf37PRc8z/ka9rt69w4Rbs20dw2Clctj
+        EDBrQq4yCodhGi968kyqN8oxJg1WVCpEioZILIGg6dskOSMI0sHw0oSCVtzQ6rlMBKsU4+UbpQ1M
+        geJiSUq2IUegYCpB0KLeKMKYwJSuEHBvtLU2TVgJtiLJs3aHoAllK3j3GN6OMXDqudJ79m+sv/Y1
+        U3RG0kJvwgXJJX05CczYCp1Mwwl21avie2eLp3S7iEFc4kzQsSuettS9m8y4sNs6O2jNOeDXPQBs
+        J5hj7k/02YOirZsQf90eSLAxyZwLovih/b1P3ADThP1/dTAoSgoP0cYcmIxzHw8ac2CYlDV9VVzu
+        m7KhyLAN/bIu5vZsek3A7wNbe+gkUrJlSamH57aIJmyPzrkgZZL5QFtCE9ovs8Jk6SFTWwMyz/nc
+        g4LrKzSIJpQZsdeEmvkp00xNGCAFXXjK1IQtUgmvNTYSNWILxB2lsNweGltC2DhP5qRc1mTpw9wi
+        9AGOq3dJNgdzin37pGMAqBMlwea17zHWUbRKe6VjX/u4soN0SJMl7E889k69l2uYyRcFO3Rn7+M5
+        wCDIvaE6LnfB+v/D6cUhqZrQhN2Jaw90xz7eq+5EbzX2R3B5uEcYtISw+bUiKtOnEwaqiKDHC3aA
+        sJkTpEBnZ2dNRolJbQsqvPaqtQeIiCRDGne8xqYlIH8piDIJ80JLTJFA55ykHj7dIoCzi3e8Tmvf
+        X/MK2Z+HOGPe5xUoNKXipc8Z2jH65JIrtmDJa+qFfVtrgGneS1Ym9IQgBUaUKpYwxC1KMb12SBmp
+        j2+sPaaAStwWCzlFCHt4W1BLaEJb26W0yvmz51nTg+jtKijqi3RGFAqR8Si6Oh29O42iaXQRj6J4
+        MnpAn7pK/99n/G4aXcfnl/G56VPVMtvFjMfT8SiOxnF0obvg6HSRjC+8DPysMO9XF7rSh5mUWWf2
+        W2cU//RBwxklOUJyZ9+8drzV7h12yBAiM17QCpmEfbSQbIOv88kgJUh4XcLJ5yfBmijkqrh+u6Y2
+        jYD912eV8VIziZzZDRzEStS6+kNLJfgjTZTst3VHRq/jmj2xgaFOdLYln63bnAA87hRMCO7ebmyF
+        6I44vMO42pNXtHSCWuV4pMpZQkuJ6Ta6iIN+XNoQ7x6d7u+mv/zhesAbVfrDPWjdTXVgDV+Khi8v
+        DixDB+w9hiWX00/548O/F5uH6e0mQJ1s68gYE+mpxGNa52zj+ZQuSJ2rmU3xtVgilSm+KyoKOFs/
+        c+ipuDLcul3HdutJfQDab4yKY4SvZ/J7TRCj5nZpu9lfTBN8pROZ4S+C6tttaFNStUY53PoWc+mn
+        am6popf/AN6BRwgnFAAA
     headers:
       access-control-allow-origin: ['*']
       access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
@@ -118,8 +115,8 @@ interactions:
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:25:57 GMT']
-      etag: [W/"e0947b2fdc6c88541c0beaa32a7f9bbb"]
+      date: ['Fri, 27 Jul 2018 19:36:30 GMT']
+      etag: [W/"9ac32567d480a8f83a4e80ac7a6d451f"]
       referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       server: [GitHub.com]
       status: [200 OK]
@@ -128,713 +125,13 @@ interactions:
       x-content-type-options: [nosniff]
       x-frame-options: [deny]
       x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['9BD0:413C:FA8A54:1CB9C0F:5B528BA5']
+      x-github-request-id: ['EBEC:5CB5:57C2157:B85D819:5B5B743D']
       x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4975']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.084991']
+      x-ratelimit-remaining: ['4938']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.104672']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: GET
-    uri: https://api.github.com/repos/jacquerie/github-file/labels?per_page=100
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA62VTW+bQBCG/8oKqcrFDdjYYPtmKR8n99JUlRpV1ZodYJ1ll+5HcV3lv3fAwaR2
-        FSwFLmjeWQ165t0ZHv94nHnLcRAEk/l8spiNPKkY/KhFb33zJXq4v+Pfvla79c2qWm+z6Xr7NPZG
-        ntMCD+TWlmbp+7Tk1xm3udtcJ6rwNZTK+Fua/HSgOfiH1MeUC/AF3YAw/sZlWEXSArDMIUiUUBoj
-        Fod0SjHLIKVOWG9ptYM6NInmpeVK4qnPqgCbc5kRbuSVJZXSTxh5z6MTougCoskARMyVgifUQsf1
-        WmrpkpSFLO6je8i5QTDjgChNSicE0YDdNJZQoYGy3wR23FhzzhtfwBsOwAsypzKBAqTtiP8VW2Y6
-        AYC0j/kTVCQFap1uoF94TwHDoN/Q/WoIQzOl2IdJkHJtLL4bNzrSOkua3MEnzLS4cTCL017c+6YA
-        gkqocGhAn3kZBv1e7ldDeJmDKBGxotIC6xhrmRzFFi8I5lFcN/jN+bzdWU0JtRbvB04sNglBgWH5
-        kwkNg3nvjd2vpvi99+4cLn9RgYvtuHc6oWWDKUTRoo+tmU6moFk8BqAgmme5PSdbXEA2G4Cs2Qz1
-        XjyivVKOe3UeR1Dfljd9u3Pa5qAJl3g3C9p69zKN/7FvHPRD3lYDQFZK2pTvOsZOaBHT5ulDbOyr
-        OO5UqSzZQPPvAEawf8/f/wK1Q1+LEQcAAA==
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      cache-control: ['private, max-age=60, s-maxage=60']
-      content-encoding: [gzip]
-      content-security-policy: [default-src 'none']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:25:57 GMT']
-      etag: [W/"eb828e900827a42324c0fe01d1659f92"]
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [200 OK]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.symmetra-preview; format=json]
-      x-github-request-id: ['9BD0:413C:FA8A6C:1CB9C59:5B528BA5']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4974']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.051719']
-      x-xss-protection: [1; mode=block]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/vnd.github.v3.full+json]
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: DELETE
-    uri: https://api.github.com/repos/jacquerie/github-file/labels/bug
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      content-security-policy: [default-src 'none']
-      content-type: [application/octet-stream]
-      date: ['Sat, 21 Jul 2018 01:25:57 GMT']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [204 No Content]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['9BD0:413C:FA8A79:1CB9C7B:5B528BA5']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4973']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.056936']
-      x-xss-protection: [1; mode=block]
-    status: {code: 204, message: No Content}
-- request:
-    body: null
-    headers:
-      Accept: [application/vnd.github.v3.full+json]
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: DELETE
-    uri: https://api.github.com/repos/jacquerie/github-file/labels/duplicate
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      content-security-policy: [default-src 'none']
-      content-type: [application/octet-stream]
-      date: ['Sat, 21 Jul 2018 01:25:57 GMT']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [204 No Content]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['9BD0:413C:FA8A85:1CB9C9A:5B528BA5']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4972']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.074165']
-      x-xss-protection: [1; mode=block]
-    status: {code: 204, message: No Content}
-- request:
-    body: null
-    headers:
-      Accept: [application/vnd.github.v3.full+json]
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: DELETE
-    uri: https://api.github.com/repos/jacquerie/github-file/labels/enhancement
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      content-security-policy: [default-src 'none']
-      content-type: [application/octet-stream]
-      date: ['Sat, 21 Jul 2018 01:25:58 GMT']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [204 No Content]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['9BD0:413C:FA8AA7:1CB9CC4:5B528BA5']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4971']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.074014']
-      x-xss-protection: [1; mode=block]
-    status: {code: 204, message: No Content}
-- request:
-    body: null
-    headers:
-      Accept: [application/vnd.github.v3.full+json]
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: DELETE
-    uri: https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      content-security-policy: [default-src 'none']
-      content-type: [application/octet-stream]
-      date: ['Sat, 21 Jul 2018 01:25:58 GMT']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [204 No Content]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['9BD0:413C:FA8ABB:1CB9D0D:5B528BA6']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4970']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.059438']
-      x-xss-protection: [1; mode=block]
-    status: {code: 204, message: No Content}
-- request:
-    body: null
-    headers:
-      Accept: [application/vnd.github.v3.full+json]
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: DELETE
-    uri: https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      content-security-policy: [default-src 'none']
-      content-type: [application/octet-stream]
-      date: ['Sat, 21 Jul 2018 01:25:58 GMT']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [204 No Content]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['9BD0:413C:FA8ACC:1CB9D2B:5B528BA6']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4969']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.063209']
-      x-xss-protection: [1; mode=block]
-    status: {code: 204, message: No Content}
-- request:
-    body: null
-    headers:
-      Accept: [application/vnd.github.v3.full+json]
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: DELETE
-    uri: https://api.github.com/repos/jacquerie/github-file/labels/invalid
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      content-security-policy: [default-src 'none']
-      content-type: [application/octet-stream]
-      date: ['Sat, 21 Jul 2018 01:25:58 GMT']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [204 No Content]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['9BD0:413C:FA8AE3:1CB9D55:5B528BA6']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4968']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.057132']
-      x-xss-protection: [1; mode=block]
-    status: {code: 204, message: No Content}
-- request:
-    body: null
-    headers:
-      Accept: [application/vnd.github.v3.full+json]
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: DELETE
-    uri: https://api.github.com/repos/jacquerie/github-file/labels/question
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      content-security-policy: [default-src 'none']
-      content-type: [application/octet-stream]
-      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [204 No Content]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['9BD0:413C:FA8AF9:1CB9D88:5B528BA6']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4967']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.083807']
-      x-xss-protection: [1; mode=block]
-    status: {code: 204, message: No Content}
-- request:
-    body: null
-    headers:
-      Accept: [application/vnd.github.v3.full+json]
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: DELETE
-    uri: https://api.github.com/repos/jacquerie/github-file/labels/wontfix
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      content-security-policy: [default-src 'none']
-      content-type: [application/octet-stream]
-      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [204 No Content]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['9BD0:413C:FA8B0D:1CB9DB2:5B528BA7']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4966']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.068660']
-      x-xss-protection: [1; mode=block]
-    status: {code: 204, message: No Content}
-- request:
-    body: !!python/unicode '{"color": "d73a4a", "name": "bug", "description": "Something
-      isn''t working"}'
-    headers:
-      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['76']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: POST
-    uri: https://api.github.com/repos/jacquerie/github-file/labels
-  response:
-    body: {string: !!python/unicode '{"id":1000288726,"node_id":"MDU6TGFiZWwxMDAwMjg4NzI2","url":"https://api.github.com/repos/jacquerie/github-file/labels/bug","name":"bug","color":"d73a4a","default":true,"description":"Something
-        isn''t working"}'}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      cache-control: ['private, max-age=60, s-maxage=60']
-      content-length: ['209']
-      content-security-policy: [default-src 'none']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
-      etag: ['"70c69d3c2e74371cdb1556aa91a1ae3b"']
-      location: ['https://api.github.com/repos/jacquerie/github-file/labels/bug']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [201 Created]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.symmetra-preview; format=json]
-      x-github-request-id: ['9BD0:413C:FA8B23:1CB9DD4:5B528BA7']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4965']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.059677']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
-- request:
-    body: !!python/unicode '{"color": "cfd3d7", "name": "duplicate", "description":
-      "This issue or pull request already exists"}'
-    headers:
-      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['100']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: POST
-    uri: https://api.github.com/repos/jacquerie/github-file/labels
-  response:
-    body: {string: !!python/unicode '{"id":1000288737,"node_id":"MDU6TGFiZWwxMDAwMjg4NzM3","url":"https://api.github.com/repos/jacquerie/github-file/labels/duplicate","name":"duplicate","color":"cfd3d7","default":true,"description":"This
-        issue or pull request already exists"}'}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      cache-control: ['private, max-age=60, s-maxage=60']
-      content-length: ['239']
-      content-security-policy: [default-src 'none']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
-      etag: ['"a7e75964d64e4f3dead233738f0127e1"']
-      location: ['https://api.github.com/repos/jacquerie/github-file/labels/duplicate']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [201 Created]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.symmetra-preview; format=json]
-      x-github-request-id: ['9BD0:413C:FA8B3A:1CB9E06:5B528BA7']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4964']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.055315']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
-- request:
-    body: !!python/unicode '{"color": "a2eeef", "name": "enhancement", "description":
-      "New feature or request"}'
-    headers:
-      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['83']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: POST
-    uri: https://api.github.com/repos/jacquerie/github-file/labels
-  response:
-    body: {string: !!python/unicode '{"id":1000288738,"node_id":"MDU6TGFiZWwxMDAwMjg4NzM4","url":"https://api.github.com/repos/jacquerie/github-file/labels/enhancement","name":"enhancement","color":"a2eeef","default":true,"description":"New
-        feature or request"}'}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      cache-control: ['private, max-age=60, s-maxage=60']
-      content-length: ['224']
-      content-security-policy: [default-src 'none']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
-      etag: ['"42e63ee987ce88605b9df8d14f497624"']
-      location: ['https://api.github.com/repos/jacquerie/github-file/labels/enhancement']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [201 Created]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.symmetra-preview; format=json]
-      x-github-request-id: ['9BD0:413C:FA8B53:1CB9E2B:5B528BA7']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4963']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.052768']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
-- request:
-    body: !!python/unicode '{"color": "7057ff", "name": "good first issue", "description":
-      "Good for newcomers"}'
-    headers:
-      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['84']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: POST
-    uri: https://api.github.com/repos/jacquerie/github-file/labels
-  response:
-    body: {string: !!python/unicode '{"id":1000288739,"node_id":"MDU6TGFiZWwxMDAwMjg4NzM5","url":"https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue","name":"good
-        first issue","color":"7057ff","default":true,"description":"Good for newcomers"}'}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      cache-control: ['private, max-age=60, s-maxage=60']
-      content-length: ['234']
-      content-security-policy: [default-src 'none']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
-      etag: ['"b3461ff5f59a8105635b1261587a5642"']
-      location: ['https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [201 Created]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.symmetra-preview; format=json]
-      x-github-request-id: ['9BD0:413C:FA8B66:1CB9E52:5B528BA7']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4962']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.057105']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
-- request:
-    body: !!python/unicode '{"color": "008672", "name": "help wanted", "description":
-      "Extra attention is needed"}'
-    headers:
-      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['86']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: POST
-    uri: https://api.github.com/repos/jacquerie/github-file/labels
-  response:
-    body: {string: !!python/unicode '{"id":1000288740,"node_id":"MDU6TGFiZWwxMDAwMjg4NzQw","url":"https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted","name":"help
-        wanted","color":"008672","default":true,"description":"Extra attention is
-        needed"}'}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      cache-control: ['private, max-age=60, s-maxage=60']
-      content-length: ['229']
-      content-security-policy: [default-src 'none']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:26:00 GMT']
-      etag: ['"69e2e9a9134e3fd94d29b23709b5fa1d"']
-      location: ['https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [201 Created]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.symmetra-preview; format=json]
-      x-github-request-id: ['9BD0:413C:FA8B80:1CB9E83:5B528BA7']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4961']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.058553']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
-- request:
-    body: !!python/unicode '{"color": "e4e669", "name": "invalid", "description":
-      "This doesn''t seem right"}'
-    headers:
-      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['80']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: POST
-    uri: https://api.github.com/repos/jacquerie/github-file/labels
-  response:
-    body: {string: !!python/unicode '{"id":1000288741,"node_id":"MDU6TGFiZWwxMDAwMjg4NzQx","url":"https://api.github.com/repos/jacquerie/github-file/labels/invalid","name":"invalid","color":"e4e669","default":true,"description":"This
-        doesn''t seem right"}'}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      cache-control: ['private, max-age=60, s-maxage=60']
-      content-length: ['217']
-      content-security-policy: [default-src 'none']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:26:00 GMT']
-      etag: ['"37eb7d37fa59b47711f74653ad82301b"']
-      location: ['https://api.github.com/repos/jacquerie/github-file/labels/invalid']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [201 Created]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.symmetra-preview; format=json]
-      x-github-request-id: ['9BD0:413C:FA8BA2:1CB9EBB:5B528BA8']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4960']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.063497']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
-- request:
-    body: !!python/unicode '{"color": "d876e3", "name": "question", "description":
-      "Further information is requested"}'
-    headers:
-      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['90']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: POST
-    uri: https://api.github.com/repos/jacquerie/github-file/labels
-  response:
-    body: {string: !!python/unicode '{"id":1000288742,"node_id":"MDU6TGFiZWwxMDAwMjg4NzQy","url":"https://api.github.com/repos/jacquerie/github-file/labels/question","name":"question","color":"d876e3","default":true,"description":"Further
-        information is requested"}'}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      cache-control: ['private, max-age=60, s-maxage=60']
-      content-length: ['228']
-      content-security-policy: [default-src 'none']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:26:00 GMT']
-      etag: ['"b411c7446fab5e80a2b026ebfb444f59"']
-      location: ['https://api.github.com/repos/jacquerie/github-file/labels/question']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [201 Created]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.symmetra-preview; format=json]
-      x-github-request-id: ['9BD0:413C:FA8BD0:1CB9F04:5B528BA8']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4959']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.064102']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
-- request:
-    body: !!python/unicode '{"color": "ffffff", "name": "wontfix", "description":
-      "This will not be worked on"}'
-    headers:
-      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
-      Accept-Charset: [utf-8]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
-      Connection: [keep-alive]
-      Content-Length: ['83']
-      Content-Type: [application/json]
-      User-Agent: [github3.py/1.1.0]
-    method: POST
-    uri: https://api.github.com/repos/jacquerie/github-file/labels
-  response:
-    body: {string: !!python/unicode '{"id":1000288743,"node_id":"MDU6TGFiZWwxMDAwMjg4NzQz","url":"https://api.github.com/repos/jacquerie/github-file/labels/wontfix","name":"wontfix","color":"ffffff","default":true,"description":"This
-        will not be worked on"}'}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      cache-control: ['private, max-age=60, s-maxage=60']
-      content-length: ['220']
-      content-security-policy: [default-src 'none']
-      content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:26:00 GMT']
-      etag: ['"a11d56874c16d6cebf1029e74a2200e1"']
-      location: ['https://api.github.com/repos/jacquerie/github-file/labels/wontfix']
-      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
-      server: [GitHub.com]
-      status: [201 Created]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
-      x-content-type-options: [nosniff]
-      x-frame-options: [deny]
-      x-github-media-type: [github.symmetra-preview; format=json]
-      x-github-request-id: ['9BD0:413C:FA8BEE:1CB9F48:5B528BA8']
-      x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4958']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.067310']
-      x-xss-protection: [1; mode=block]
-    status: {code: 201, message: Created}
 - request:
     body: !!python/unicode '{"names": ["github", "configuration", "file"]}'
     headers:
@@ -862,7 +159,7 @@ interactions:
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      date: ['Sat, 21 Jul 2018 01:26:00 GMT']
+      date: ['Fri, 27 Jul 2018 19:36:30 GMT']
       etag: [W/"a3d0f31fe3b28b17d94593008a4c5352"]
       referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       server: [GitHub.com]
@@ -872,11 +169,711 @@ interactions:
       x-content-type-options: [nosniff]
       x-frame-options: [deny]
       x-github-media-type: [github.mercy-preview; format=json]
-      x-github-request-id: ['9BD0:413C:FA8C1F:1CB9F99:5B528BA8']
+      x-github-request-id: ['EBEC:5CB5:57C21AE:B85D8FE:5B5B743E']
       x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4957']
-      x-ratelimit-reset: ['1532139803']
-      x-runtime-rack: ['0.124670']
+      x-ratelimit-remaining: ['4937']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.237979']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: GET
+    uri: https://api.github.com/repos/jacquerie/github-file/labels?per_page=100
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA63VUW/aMBAH8K9iRZr2wpoEaEJ5qwTtE9vDOk3aNE0mvhCvjp3Z54Vt6nfvJTSk
+        G1XJQ3hBPkdGP/9zx9e/gRTBMo6iNLqKF9FsEmgj4HtTDDarT8nd7Y388rneb1bXs83qfv9hdf0n
+        mATeKnqgQKzcMgx5JS92Egu/vchMGVqojAt/8OynByshPGy9y6WCUPEtKBdu/Y5O0bwEOuawyIwy
+        llYinfE5p10BOfcKgyVaD83SZVZWKI2mpz6aErCQesek02+R1cbe0yp4mPwnmg8QRSOIhK+UzDhC
+        73pe6nRZLmYiPae7K6QjmPPAjGWVV4pZoNt0yLiywMVvBnvp0J16Lwd44xG8oAuuMyhBYy/+t9iZ
+        +RQA8nPm91CzHDh626KfvKfAZABwOgJwZ4x4M41yaR3Sd5tGL212Wbt3yIl2Om4aXab5We5tewBB
+        NdTUNGBfyDIdQJ2NQC1AVUSsuUYQvbEps2Ox40XRIkmbC361P9d7tJxxRHo/qGPpkggKgo4/6dDF
+        AOV8BKXUv7iiwXacO32hs8EckuTqnK3tTmGgHTwOoGRW7go8kcUD8luPkV87GZq5eKQ9qxzn6iJN
+        oPm1V3O78RYLsExqejdL3mX31I0vxBcPiG89Rny10ZjLfW/sCx0xbz/niG18taSZqg2yLbT/HSAY
+        3d/Dt0cN1OkZEQcAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:31 GMT']
+      etag: [W/"62be449025c3ab4090b90dc237ff0d9a"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C2221:B85D9FC:5B5B743E']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4936']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.052571']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/bug
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:31 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C2263:B85DA9B:5B5B743F']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4935']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.081178']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/duplicate
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:31 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C2294:B85DB1A:5B5B743F']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4934']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.079770']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/enhancement
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:31 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C22CD:B85DB83:5B5B743F']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4933']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.080225']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:32 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C230C:B85DBFA:5B5B743F']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4932']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.066161']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:32 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C2343:B85DC68:5B5B7440']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4931']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.082709']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/invalid
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:32 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C2381:B85DCD6:5B5B7440']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4930']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.083456']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/question
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:32 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C23B7:B85DD4C:5B5B7440']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4929']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.077826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/wontfix
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Fri, 27 Jul 2018 19:36:33 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C23F3:B85DDB8:5B5B7440']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4928']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.059686']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{"color": "d73a4a", "name": "bug", "description": "Something
+      isn''t working"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['76']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007091996,"node_id":"MDU6TGFiZWwxMDA3MDkxOTk2","url":"https://api.github.com/repos/jacquerie/github-file/labels/bug","name":"bug","color":"d73a4a","default":true,"description":"Something
+        isn''t working"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['209']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:33 GMT']
+      etag: ['"548a0a71a07dc297d589eb816b90d1ef"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/bug']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C2440:B85DE31:5B5B7441']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4927']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.070178']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "cfd3d7", "name": "duplicate", "description":
+      "This issue or pull request already exists"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092004,"node_id":"MDU6TGFiZWwxMDA3MDkyMDA0","url":"https://api.github.com/repos/jacquerie/github-file/labels/duplicate","name":"duplicate","color":"cfd3d7","default":true,"description":"This
+        issue or pull request already exists"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['239']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:33 GMT']
+      etag: ['"50cb8fe904d1fd267cbbd7e4e725f4e1"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/duplicate']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C2485:B85DED2:5B5B7441']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4926']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.077209']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "a2eeef", "name": "enhancement", "description":
+      "New feature or request"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['83']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092005,"node_id":"MDU6TGFiZWwxMDA3MDkyMDA1","url":"https://api.github.com/repos/jacquerie/github-file/labels/enhancement","name":"enhancement","color":"a2eeef","default":true,"description":"New
+        feature or request"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['224']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:33 GMT']
+      etag: ['"5492b0012865548502ea2e4db7714020"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/enhancement']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C24CC:B85DF7F:5B5B7441']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4925']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.067916']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "7057ff", "name": "good first issue", "description":
+      "Good for newcomers"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['84']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092006,"node_id":"MDU6TGFiZWwxMDA3MDkyMDA2","url":"https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue","name":"good
+        first issue","color":"7057ff","default":true,"description":"Good for newcomers"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['234']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:34 GMT']
+      etag: ['"aa40129db12a8c2bd873ccf29e761be4"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C2502:B85DFF7:5B5B7441']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4924']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.062944']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "008672", "name": "help wanted", "description":
+      "Extra attention is needed"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['86']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092009,"node_id":"MDU6TGFiZWwxMDA3MDkyMDA5","url":"https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted","name":"help
+        wanted","color":"008672","default":true,"description":"Extra attention is
+        needed"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['229']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:34 GMT']
+      etag: ['"695be887951143e3d62ea27c57780515"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C2539:B85E057:5B5B7442']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4923']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.070108']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "e4e669", "name": "invalid", "description":
+      "This doesn''t seem right"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['80']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092016,"node_id":"MDU6TGFiZWwxMDA3MDkyMDE2","url":"https://api.github.com/repos/jacquerie/github-file/labels/invalid","name":"invalid","color":"e4e669","default":true,"description":"This
+        doesn''t seem right"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['217']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:34 GMT']
+      etag: ['"0a34aa7af688025afb5d1732a650872d"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/invalid']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C2571:B85E0E2:5B5B7442']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4922']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.232550']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "d876e3", "name": "question", "description":
+      "Further information is requested"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['90']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092025,"node_id":"MDU6TGFiZWwxMDA3MDkyMDI1","url":"https://api.github.com/repos/jacquerie/github-file/labels/question","name":"question","color":"d876e3","default":true,"description":"Further
+        information is requested"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['228']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:35 GMT']
+      etag: ['"c0ed259b9c11579b278c56633aa6a699"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/question']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C25C5:B85E182:5B5B7442']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4921']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.062509']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "ffffff", "name": "wontfix", "description":
+      "This will not be worked on"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['83']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1007092026,"node_id":"MDU6TGFiZWwxMDA3MDkyMDI2","url":"https://api.github.com/repos/jacquerie/github-file/labels/wontfix","name":"wontfix","color":"ffffff","default":true,"description":"This
+        will not be worked on"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['220']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 27 Jul 2018 19:36:35 GMT']
+      etag: ['"68d0c6c4a59042a6c385911cb3335036"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/wontfix']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['EBEC:5CB5:57C25F1:B85E1E9:5B5B7443']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4920']
+      x-ratelimit-reset: ['1532723712']
+      x-runtime-rack: ['0.065892']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
 version: 1

--- a/tests/cassettes/test_update_uses_the_provided_filename.yaml
+++ b/tests/cassettes/test_update_uses_the_provided_filename.yaml
@@ -14,30 +14,30 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6WYUW/bNhDHv4rg1zmRlTppYiDoijXIMixpN7hbkReDlmiLiUSqJGXXFvLd9ycp
-        W5JX2In5Ytg078fj8e54x6rHkt4oGg7Or6LhedTvcZHQiRnr3X+6WX7O/sji26s1+fb3IubPPx4+
-        fYw+j28GD+Ob6x4mk5xi5pzptJyezFhGMTgrs2xS//NE4u8llYyG3TliyansjapeJuaMA7GdCIBZ
-        /d1ldHY56Krz18U/3x6y+Ol+eD++G95/vDYqkAXRRE5KmYGSal2oURi6QXV26lYtFZWx4JpyfRqL
-        PCxDh/+wuB4CMZc1xG4bAzuwgtUcJwyYCtv6pjrPdhRw69r57ZkzkWViCfldffcuEW7FjHUtgvH5
-        MQiIVaHQKYXBsI0Xs3mm9BvVsSIVTlRpeIqBKByBpMnbVKqFoJBxhpcqlLQQllZOVSxZoZngb1St
-        IwqUkHPC2ZocgYKoAsEo9UYlrAhE6QIO90ZZJ1OFhWQLEq+MOSSNKVvAusfwdoSB06vCxOxXnL+x
-        NdN0QpLcBOGMZIq+9Ht2bY1JdqCPqHqVf++EeEK3h4jlfhN8xualpMFKlDK4Zfr3chpYSzEt5CqY
-        SZEHJDA5pB8skVBEqYOULOCygRZBnLH4OSBSlDwJGA/gw8HXu1PsYCbk81bVvZFrV2vicUdfwzlw
-        WHsAiFGIQ51nuvKgGOkqxGcdWDGinUyFJLCRB7aDqcL2T+NhmpLcg27FgUmF8LGgFQeGKVXSVzn7
-        vvOwFBVu4omX+dQlvNdE0T6wk4eeRCk255R6WG6LqMJNPp5KwuPUB7ohVKH7Zk+YzD3UNNKATDMx
-        9aDgTgwtogpVStzdoyd+mhmmIXSQks481TSELVJLrzO2KhrEFoiLT+O4PXTcEMKqtmRG+Lwkcx/m
-        FoGTNlfznKwPFir74qRhAGiqL8mmpW8aayhGS1cnIK59TNlAGqQtPfZXM3u33ipg7ObznB0qBPbx
-        akDHyb2hxi93web34ZrlkKqGUIVNxnUJvWYfb9U6o290bK9QF/cebrAhhNUvBdGpyU5YqCCSHq9w
-        DQirKUFddXp6WqWU2Ho5p9IrVp08QETGKWrD43WsNgTULznRtgqfGRUTVOWZIImHTbcI4NzhHa+n
-        k2+feYE200M5K97m5ag8lRbcJ4c2jDaZC81mLH5NE7IvtDqY6oNiPKZ9kmV9eKlmMYPfolg2Z4eS
-        kfrYxsljC2jvXQeSUbiwh7UldYQqdA1jQotMrDxzTQtiwlVSNC3JhGi0G2eD6PJk8P4kisbR+WgQ
-        jYaDR8wpi+Qnc96PMeHd1ej8yswpSpX+D3MxHpyNzjDFYpA6a0/GNzw34BPvH91uv91dmOcDiCmV
-        NmK/NkKjn76S1EJxBpfciZvXrrfYvcMOCULJVOS0QCXhXkIUW+NbhHehVkkQowmDkfE6syQatSqu
-        32ZoU0ZA/ssKXRw3TKImLoB7Iy1L01JipJDiicZatcealNGauGTPrGlGjaSpdLYjrnFrNMiZlKJ+
-        EeKI8m2WxOtO3dGKgvJao7bqLKZcYb+V6eKwAdza0L5+yrq/Gwd/1jNgjiL5UT+T3Y2NZ3Xfn7rv
-        OehdDViFNbD1xBZfjG+zp8d/z9eP45t1D923aySNdVtadqxtfyR0RspMT1yNb5QlStuWvqAyh7XN
-        44nZSt3cO7sb597Y22RA9x2rIo+I5UR9Lwmc1F4vm2nuHzsEW5lKpvuPpOZ668pwqpfoh1u2bddq
-        9VFFL/8B0z3YN30UAAA=
+        H4sIAAAAAAAAA6WYYW/bNhCG/4rgr3MsK3Ha1EDQFWvQZVjSbnC3Il8MWqItJhKpkpRdW8h/30tS
+        tiSvsBPzi2HLvIcvj3fUHaseS3rjaDS8fBeNLqN+j4uETs2z3t3Hm9Xn7I8s/vRuQ779vYz504/7
+        jx+iz5Ob4f3k5rqHwSSnGLlgOi1nZ3OWUTycl1k2rf95JPH3kkpGw+4YseJU9sZVLxMLxoHYDQTA
+        zH5xFZ1fDbty/nrzz7f7LH68G91Nbkd3H66NBLIkmshpKTNQUq0LNQ5D91CdD9yspaIyFlxTrgex
+        yMMydPj3y+sREAtZQ+yy8WAPVrCa44wBU2Fbb6rzbE+Am9eOb4+ciywTK9jv6z04RbgzM961CMYX
+        pyBgVoVCpxQOwzKezeKZ0q+UY00q7KjSiBQDUdgCSZPXSaqNIMgEw3MVSloISytnKpas0EzwV0rr
+        mAIl5IJwtiEnoGCqQDCiXinCmsCULhFwr7R1NlVYSLYk8dq4Q9KYsiW8ewpvzxg4vS5Mzn7F/htf
+        M02nJMlNEs5Jpuhzv2fn1hhkH/SRVS+K770UT+huEzHdb4LP2aKUNFiLUgafmP69nAXWU0wLuQ7m
+        UuQBCcwZ0g9WOFBEqYOULBGygRZBnLH4KSBSlDwJGA8Qw8HX2wFWMBfyaSf1YOba2Zp83NNrOEc2
+        6wAAOQpzyHmiaw+Ksa5CfNaJFSPbyUxIAh95YDuYKmz/NBGmKck96NYcmFQIHw9ac2CYUiV9UbAf
+        2g9LUeE2n3iZz9yB95IsOgR29tBJlGILTqmH53aIKtyexzNJeJz6QLeEKnTf7A6ThYdMYw3ILBMz
+        DwreiaFFVKFKiXv36KmfMsM0hA5S0rmnTEPYIbX02mMr0SB2QLz4NLbbQ+OWEFa1JzPCFyVZ+DB3
+        COy0eTUvyOZooXIoTxoGgKb6kmxW+h5jDcWodHUC8trHlQ2kQdrS43A1c3DprQLGLj7P2bFC4BCv
+        BnSC3Btq4nIfbH4fr1mOSTWEKmxOXHeg1+zTvVqf6FuN7Rnq4t4jDLaEsPqlIDo1pxMmKoikpwuu
+        AWE1I6irBoNBlVJi6+WcSq9cdfYAERmnqA1P11htCahfcqJtFT43EhNU5ZkgiYdPdwjg3OadrtPZ
+        t/e8QJvpIc6at3k5Kk+lBfc5QxtGm8yFZnMWv6QJOZRaHUz1XjEe0z7Jsj6iVLOYIW5RLJu9Q8lI
+        fXzj7LEEtPeuA8koQtjD25I6QhW6hjGhRSbWnmdNC2LSVVI0LcmUaLQb58Po6mz49iyKJtHleBiN
+        R8MHjCmL5Cdj3k6Go/FFNI6uzJiiVOn/MHbI+fl4dGGG4OisIxnfcN2AT9x/dLv9dndhrg9gplTa
+        mP3aGI1/ektSG8UZQnIvb14633L/HXbMECJTkdMClYS7CVFsg28R7oVaJUGMJgxOxu3MimjUqnj9
+        No+2ZQTsv6zRxXHDJGrqErg31rI0LSWeFFI80lirps/Ew+bMaI1csSfWGWUENnauc2sk5ExKUV8J
+        caT57pjE9U7d0oqC8lpSWzuLKVdYcGXaOKwAr23Ir++y7m4nwZ/1CPijSH7U92S3ExNa3Quo7oUO
+        mlcDVmENbN2xxW8mn7LHh38vNw+Tm00P7bfrJI17Wyo77rY/EjonZaanrsg3YonStqcvqMzhbnN7
+        YpZSd/fO8Sa6t5tgjkD3HbPiIBGrqfpeEkSpfb/snOX+ss/gLFPL7P0lqXnDba3cRJzqFVrilnfb
+        5Vq9WdHzfxVRe9SAFAAA
     headers:
       access-control-allow-origin: ['*']
       access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
@@ -47,9 +47,9 @@ interactions:
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 17 Jul 2018 03:16:34 GMT']
-      etag: [W/"8929e63f370498fd49729e09c40a7e77"]
-      last-modified: ['Tue, 17 Jul 2018 01:39:59 GMT']
+      date: ['Tue, 17 Jul 2018 04:32:25 GMT']
+      etag: [W/"92f1cfadbb4c24b21c8dac5d1504361d"]
+      last-modified: ['Tue, 17 Jul 2018 04:31:18 GMT']
       referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       server: [GitHub.com]
       status: [200 OK]
@@ -58,11 +58,11 @@ interactions:
       x-content-type-options: [nosniff]
       x-frame-options: [deny]
       x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['808A:7DB4:4FC3D29:B32602C:5B4D5F91']
+      x-github-request-id: ['853C:7DB6:ABFE3CF:15E81EBD:5B4D7158']
       x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4998']
-      x-ratelimit-reset: ['1531800890']
-      x-runtime-rack: ['0.086904']
+      x-ratelimit-remaining: ['4984']
+      x-ratelimit-reset: ['1531804963']
+      x-runtime-rack: ['0.067013']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -85,30 +85,30 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6WYYW/bNhCG/4rgr3MiK3HSxEDQFWvQZVjSbnC3Il8MWqItJhKpkpRdW8h/30tS
-        tiSvsBPzi2HLvIcvj3fUHaseS3qjaDi4uI6GF1G/x0VCJ+ZZ7/7j7fJz9kcWf7pek29/L2L+/OPh
-        44fo8/h28DC+velhMMkpRs6ZTsvpyYxlFA9nZZZN6n+eSPy9pJLRsDtGLDmVvVHVy8SccSC2AwEw
-        s59fRWdXg66cvy7/+faQxU/3w/vx3fD+w42RQBZEEzkpZQZKqnWhRmHoHqqzUzdrqaiMBdeU69NY
-        5GEZOvz7xc0QiLmsIXbZeLADK1jNccaAqbCtN9V5tiPAzWvHt0fORJaJJex39e6dItyaGe9aBOPz
-        YxAwq0KhUwqHYRkvZvFM6TfKsSYVdlRpRIqBKGyBpMnbJNVGEGSC4aUKJS2EpZVTFUtWaCb4G6V1
-        TIESck44W5MjUDBVIBhRbxRhTWBKFwi4N9o6myosJFuQeGXcIWlM2QLePYa3YwycXhUmZ79i/42v
-        maYTkuQmCWckU/Sl37NzawyyD/rIqlfF906KJ3S7iZjuN8FnbF5KGqxEKYNPTP9eTgPrKaaFXAUz
-        KfKABOYM6QdLHCii1EFKFgjZQIsgzlj8HBApSp4EjAeI4eDr3SlWMBPyeSt1b+ba2Zp83NFrOAc2
-        aw8AOQpzyHmmKw+Ksa5CfNaJFSPbyVRIAh95YDuYKmz/NBGmKck96NYcmFQIHw9ac2CYUiV9VbDv
-        2w9LUeEmn3iZT92B95os2gd29tBJlGJzTqmH57aIKtycx1NJeJz6QDeEKnTf7A6TuYdMYw3INBNT
-        DwreiaFFVKFKiXv36ImfMsM0hA5S0pmnTEPYIrX02mMr0SC2QLz4NLbbQ+OGEFa1JzPC5yWZ+zC3
-        COy0eTXPyfpgobIvTxoGgKb6kmxa+h5jDcWodHUC8trHlQ2kQdrSY381s3fprQLGLj7P2aFCYB+v
-        BnSC3Btq4nIXbH4frlkOSTWEKmxOXHeg1+zjvVqf6BuN7Rnq4t4jDDaEsPqlIDo1pxMmKoikxwuu
-        AWE1JairTk9Pq5QSWy/nVHrlqrMHiMg4RW14vMZqQ0D9khNtq/CZkZigKs8ESTx8ukUA5zbveJ3O
-        vr3nBdpMD3HWvM3LUXkqLbjPGdow2mQuNJux+DVNyL7U6mCq94rxmPZJlvURpZrFDHGLYtnsHUpG
-        6uMbZ48loL13HUhGEcIe3pbUEarQNYwJLTKx8jxrWhCTrpKiaUkmRKPdOBtEVyeDdydRNI4uRoNo
-        NBw8YkxZJD8Z8248OB9Fl6PzoRlTlCr9H+ZyPDgbnV2PLiwGR2cdyfiG6wZ84v6j2+23uwtzfQAz
-        pdLG7NfGaPTTW5LaKM4Qkjt589r5FrvvsEOGEJmKnBaoJNxNiGJrfItwL9QqCWI0YXAybmeWRKNW
-        xeu3ebQpI2D/ZYUujhsmUROXwL2RlqVpKfGkkOKJxlo1fSYeNmdGa+SSPbPOKCOwsXOdWyMhZ1KK
-        +kqII823xySud+qWVhSU15La2llMucKCK9PGYQV4bUN+fZd1fzcO/qxHwB9F8qO+J7sbm9DqXkB1
-        L3TQvBqwCmtg644tvhx/yp4e/71YP45v1z20366TNO5tqey42/5I6IyUmZ64It+IJUrbnr6gMoe7
-        ze2JWUrd3TvHm+jebII5At13zIqDRCwn6ntJEKX2/bJ1lvvLPoOzTC2z85ek5g23sXITcaqXaIlb
-        3m2Xa/VmRS//AYS3n7KAFAAA
+        H4sIAAAAAAAAA6WYYW/bNhCG/4rgr3Miy3Ha1EDQFWvQZVjSbnC3Il8MWqItJhKpkpRdW8h/30tS
+        tiSvsBPzi2HLvIcvj3fUHaseS3rjaDS4fBeNLqN+j4uETs2z3t3Hm9Xn7I8s/vRuQ779vYz504/7
+        jx+iz5Obwf3k5rqHwSSnGLlgOi1nZ3OWUTycl1k2rf95JPH3kkpGw+4YseJU9sZVLxMLxoHYDQTA
+        zH5xFQ2vBl05f73559t9Fj/eje4mt6O7D9dGAlkSTeS0lBkoqdaFGoehe6iG527WUlEZC64p1+ex
+        yMMydPj3y+sREAtZQ+yy8WAPVrCa44wBU2Fbb6rzbE+Am9eOb4+ciywTK9jv6z04RbgzM961CMYX
+        pyBgVoVCpxQOwzKezeKZ0q+UY00q7KjSiBQDUdgCSZPXSaqNIMgEw3MVSloISytnKpas0EzwV0rr
+        mAIl5IJwtiEnoGCqQDCiXinCmsCULhFwr7R1NlVYSLYk8dq4Q9KYsiW8ewpvzxg4vS5Mzn7F/htf
+        M02nJMlNEs5Jpuhzv2fn1hhkH/SRVS+K770UT+huEzHdb4LP2aKUNFiLUgafmP69nAXWU0wLuQ7m
+        UuQBCcwZ0g9WOFBEqYOULBGygRZBnLH4KSBSlDwJGA8Qw8HX23OsYC7k007qwcy1szX5uKfXcI5s
+        1gEAchTmkPNE1x4UY12F+KwTK0a2k5mQBD7ywHYwVdj+aSJMU5J70K05MKkQPh605sAwpUr6omA/
+        tB+WosJtPvEyn7kD7yVZdAjs7KGTKMUWnFIPz+0QVbg9j2eS8Dj1gW4JVei+2R0mCw+ZxhqQWSZm
+        HhS8E0OLqEKVEvfu0VM/ZYZpCB2kpHNPmYawQ2rptcdWokHsgHjxaWy3h8YtIaxqT2aEL0qy8GHu
+        ENhp82pekM3RQuVQnjQMAE31Jdms9D3GGopR6eoE5LWPKxtIg7Slx+Fq5uDSWwWMXXyes2OFwCFe
+        DegEuTfUxOU+2Pw+XrMck2oIVdicuO5Ar9mne7U+0bca2zPUxb1HGGwJYfVLQXRqTidMVBBJTxdc
+        A8JqRlBXnZ+fVykltl7OqfTKVWcPEJFxitrwdI3VloD6JSfaVuFzIzFBVZ4Jknj4dIcAzm3e6Tqd
+        fXvPC7SZHuKseZuXo/JUWnCfM7RhtMlcaDZn8UuakEOp1cFU7xXjMe2TLOsjSjWLGeIWxbLZO5SM
+        1Mc3zh5LQHvvOpCMIoQ9vC2pI1ShaxgTWmRi7XnWtCAmXSVF05JMiUa7MRxEV2eDt2dRNIkux4No
+        PBo8YExZJD8Z83YyGI0vhuPhpRlTlCr9H8YOGQ7HowszBEdnHcn4husGfOL+o9vtt7sLc30AM6XS
+        xuzXxmj801uS2ijOEJJ7efPS+Zb777BjhhCZipwWqCTcTYhiG3yLcC/UKgliNGFwMm5nVkSjVsXr
+        t3m0LSNg/2WNLo4bJlFTl8C9sZalaSnxpJDikcZaNX0mHjZnRmvkij2xzigjsLFznVsjIWdSivpK
+        iCPNd8ckrnfqllYUlNeS2tpZTLnCgivTxmEFeG1Dfn2XdXc7Cf6sR8AfRfKjvie7nZjQ6l5AdS90
+        0LwasAprYOuOLX4z+ZQ9Pvx7uXmY3Gx6aL9dJ2nc21LZcbf9kdA5KTM9dUW+EUuUtj19QWUOd5vb
+        E7OUurt3jjfRvd0EcwS675gVB4lYTdX3kiBK7ftl5yz3l30GZ5laZu8vSc0bbmvlJuJUr9ASt7zb
+        LtfqzYqe/wOdAmTxgBQAAA==
     headers:
       access-control-allow-origin: ['*']
       access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
@@ -118,8 +118,8 @@ interactions:
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 17 Jul 2018 03:16:34 GMT']
-      etag: [W/"d7e3c99a6e0072154d8832f13b27f455"]
+      date: ['Tue, 17 Jul 2018 04:32:25 GMT']
+      etag: [W/"2b16f79d5910ccf732ccb6923b737231"]
       referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       server: [GitHub.com]
       status: [200 OK]
@@ -128,11 +128,55 @@ interactions:
       x-content-type-options: [nosniff]
       x-frame-options: [deny]
       x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['808A:7DB4:4FC3D37:B326048:5B4D5F92']
+      x-github-request-id: ['853C:7DB6:ABFE3FC:15E81F22:5B4D7159']
       x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4997']
-      x-ratelimit-reset: ['1531800890']
-      x-runtime-rack: ['0.115527']
+      x-ratelimit-remaining: ['4983']
+      x-ratelimit-reset: ['1531804963']
+      x-runtime-rack: ['0.102689']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"names": ["github", "configuration", "file"]}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.mercy-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['46']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: PUT
+    uri: https://api.github.com/repos/jacquerie/github-file/topics
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWykvMTS1WsopWSs8syShNUtJRSs7PS8tMLy1KLMnMzwPy0zJzUpViawHy0kXo
+        KwAAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 17 Jul 2018 04:32:26 GMT']
+      etag: [W/"a3d0f31fe3b28b17d94593008a4c5352"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.mercy-preview; format=json]
+      x-github-request-id: ['853C:7DB6:ABFE41C:15E81F86:5B4D7159']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4982']
+      x-ratelimit-reset: ['1531804963']
+      x-runtime-rack: ['0.195925']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/cassettes/test_update_uses_the_provided_filename.yaml
+++ b/tests/cassettes/test_update_uses_the_provided_filename.yaml
@@ -14,30 +14,30 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6WYUW/iOBDHv0rE61FCunSvRar2VrfVXk/X7t6JvVv1BZnEELeJnbUdWIj63e9v
-        O5AEVdDiFwTG8/N4PDOecdVjSW8cjYYXV9HoIur3uEjo1Iz17j7drL5kf2bx56sN+f7PMuZPP+8/
-        fYy+TG6G95Ob6x4mk5xi5oLptJydzVlGMTgvs2xa//NI4h8llYyG3TlixansjateJhaMA7GbCIBZ
-        /d1ldH457Krz9/t/v99n8ePd6G5yO7r7eG1UIEuiiZyWMgMl1bpQ4zB0g+p84FYtFZWx4JpyPYhF
-        Hpahw39YXo+AWMgaYreNgT1YwWqOEwZMhW19U51newq4de389sy5yDKxgvy+vgeXCHdixroWwfji
-        FATEqlDolMJg2Maz2TxT+o3qWJEKJ6o0PMVAFI5A0uRtKtVCUMg4w3MVSloISytnKpas0EzwN6rW
-        EQVKyAXhbENOQEFUgWCUeqMSVgSidAmHe6Osk6nCQrIlidfGHJLGlC1h3VN4e8LA6XVhYvYbzt/Y
-        mmk6JUlugnBOMkWf+z27tsYkO9BHVL3Kv/dCPKG7Q8Ryvws+Z4tS0mAtShl8ZvqPchZYSzEt5DqY
-        S5EHJDA5pB+skFBEqYOULOGygRZBnLH4KSBSlDwJGA/gw8G32wF2MBfyaafqwci1qzXxuKev4Rw5
-        rAMAxCjEoc4TXXtQjHQV4rMOrBjRTmZCEtjIA9vBVGH7p/EwTUnuQbfiwKRC+FjQigPDlCrpq5z9
-        0HlYigq38cTLfOYS3mui6BDYyUNPohRbcEo9LLdDVOE2H88k4XHqA90SqtB9sydMFh5qGmlAZpmY
-        eVBwJ4YWUYUqJe7u0VM/zQzTEDpISeeeahrCDqml1xlbFQ1iB8TFp3HcHjpuCWFVWzIjfFGShQ9z
-        h8BJm6t5QTZHC5VDcdIwADTVl2Sz0jeNNRSjpasTENc+pmwgDdKWHoermYNbbxUwdvN5zo4VAod4
-        NaDj5N5Q45f7YPP7eM1yTFVDqMIm47qEXrNPt2qd0bc6tleoi3sPN9gSwuqXgujUZCcsVBBJT1e4
-        BoTVjKCuGgwGVUqJrZdzKr1i1ckDRGScojY8XcdqS0D9khNtq/C5UTFBVZ4JknjYdIcAzh3e6Xo6
-        +faZF2gzPZSz4m1ejspTacF9cmjDaJO50GzO4tc0IYdCq4OpPijGY9onWdaHl2oWM/gtimVzdigZ
-        qY9tnDy2gPbedSAZhQt7WFtSR6hC1zAmtMjE2jPXtCAmXCVF05JMiUa7cT6MLs+Gv55F0SS6GA+j
-        8Wj4gDllkbww52JyHo3P342HV2ZOUar0BQz+301B6qw9Gd/w3IBPvH90u/12d2GeD0BWKm3EfmuE
-        xi++ktRCcQaX3Iub16633L/DjglCyVTktEAl4V5CFNvg20WnIojRg8HGeJxZEY1SFbdvM7StIiD+
-        dY0mjhskUVMXv72xlqXpKDFSSPFIY63aY03GaE1csSfW9KJG0hQ6uxHXtzUa5ExKUT8IcQT5Lkni
-        caduaEVBea1RW3UWU66w3co0cdgALm1oX79k3d1Ogr/qGTBHkfysX8luJ8axus9P3ecctK4GrMIa
-        2Hphi99PPmePD/9dbB4mN5semm/XRxrrtrTsWNv+SOiclJmeuhLfKEuUth19QWUOa5u3E7OVurd3
-        dje+vbW3SYDuO1ZFGhGrqfpREviovV2209w/dgi2MoVM9x9Jze3WleFUr9AOt2zbLtXqo4qe/wc+
-        aoEGfBQAAA==
+        H4sIAAAAAAAAA6WYUW/bNhDHv4rg1zmRlTppYiDoijXIMixpN7hbkReDlmiLiUSqJGXXFvLd9ycp
+        W5JX2In5Ytg078fj8e54x6rHkt4oGg7Or6LhedTvcZHQiRnr3X+6WX7O/sji26s1+fb3IubPPx4+
+        fYw+j28GD+Ob6x4mk5xi5pzptJyezFhGMTgrs2xS//NE4u8llYyG3TliyansjapeJuaMA7GdCIBZ
+        /d1ldHY56Krz18U/3x6y+Ol+eD++G95/vDYqkAXRRE5KmYGSal2oURi6QXV26lYtFZWx4JpyfRqL
+        PCxDh/+wuB4CMZc1xG4bAzuwgtUcJwyYCtv6pjrPdhRw69r57ZkzkWViCfldffcuEW7FjHUtgvH5
+        MQiIVaHQKYXBsI0Xs3mm9BvVsSIVTlRpeIqBKByBpMnbVKqFoJBxhpcqlLQQllZOVSxZoZngb1St
+        IwqUkHPC2ZocgYKoAsEo9UYlrAhE6QIO90ZZJ1OFhWQLEq+MOSSNKVvAusfwdoSB06vCxOxXnL+x
+        NdN0QpLcBOGMZIq+9Ht2bY1JdqCPqHqVf++EeEK3h4jlfhN8xualpMFKlDK4Zfr3chpYSzEt5CqY
+        SZEHJDA5pB8skVBEqYOULOCygRZBnLH4OSBSlDwJGA/gw8HXu1PsYCbk81bVvZFrV2vicUdfwzlw
+        WHsAiFGIQ51nuvKgGOkqxGcdWDGinUyFJLCRB7aDqcL2T+NhmpLcg27FgUmF8LGgFQeGKVXSVzn7
+        vvOwFBVu4omX+dQlvNdE0T6wk4eeRCk255R6WG6LqMJNPp5KwuPUB7ohVKH7Zk+YzD3UNNKATDMx
+        9aDgTgwtogpVStzdoyd+mhmmIXSQks481TSELVJLrzO2KhrEFoiLT+O4PXTcEMKqtmRG+Lwkcx/m
+        FoGTNlfznKwPFir74qRhAGiqL8mmpW8aayhGS1cnIK59TNlAGqQtPfZXM3u33ipg7ObznB0qBPbx
+        akDHyb2hxi93web34ZrlkKqGUIVNxnUJvWYfb9U6o290bK9QF/cebrAhhNUvBdGpyU5YqCCSHq9w
+        DQirKUFddXp6WqWU2Ho5p9IrVp08QETGKWrD43WsNgTULznRtgqfGRUTVOWZIImHTbcI4NzhHa+n
+        k2+feYE200M5K97m5ag8lRbcJ4c2jDaZC81mLH5NE7IvtDqY6oNiPKZ9kmV9eKlmMYPfolg2Z4eS
+        kfrYxsljC2jvXQeSUbiwh7UldYQqdA1jQotMrDxzTQtiwlVSNC3JhGi0G2eD6PJk8P4kisbR+WgQ
+        jYaDR8wpi+Qnc96PMeHd1ej8yswpSpX+D3MxHpyNzjDFYpA6a0/GNzw34BPvH91uv91dmOcDiCmV
+        NmK/NkKjn76S1EJxBpfciZvXrrfYvcMOCULJVOS0QCXhXkIUW+NbhHehVkkQowmDkfE6syQatSqu
+        32ZoU0ZA/ssKXRw3TKImLoB7Iy1L01JipJDiicZatcealNGauGTPrGlGjaSpdLYjrnFrNMiZlKJ+
+        EeKI8m2WxOtO3dGKgvJao7bqLKZcYb+V6eKwAdza0L5+yrq/Gwd/1jNgjiL5UT+T3Y2NZ3Xfn7rv
+        OehdDViFNbD1xBZfjG+zp8d/z9eP45t1D923aySNdVtadqxtfyR0RspMT1yNb5QlStuWvqAyh7XN
+        44nZSt3cO7sb597Y22RA9x2rIo+I5UR9Lwmc1F4vm2nuHzsEW5lKpvuPpOZ668pwqpfoh1u2bddq
+        9VFFL/8B0z3YN30UAAA=
     headers:
       access-control-allow-origin: ['*']
       access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
@@ -47,9 +47,9 @@ interactions:
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 15 Jul 2018 22:25:30 GMT']
-      etag: [W/"497305d747d01b0c563b8f38a552cf10"]
-      last-modified: ['Sun, 15 Jul 2018 21:23:09 GMT']
+      date: ['Tue, 17 Jul 2018 03:16:34 GMT']
+      etag: [W/"8929e63f370498fd49729e09c40a7e77"]
+      last-modified: ['Tue, 17 Jul 2018 01:39:59 GMT']
       referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       server: [GitHub.com]
       status: [200 OK]
@@ -58,24 +58,26 @@ interactions:
       x-content-type-options: [nosniff]
       x-frame-options: [deny]
       x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['8982:7DB6:A098CBC:147496BE:5B4BC9D9']
+      x-github-request-id: ['808A:7DB4:4FC3D29:B32602C:5B4D5F91']
       x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4999']
-      x-ratelimit-reset: ['1531697130']
-      x-runtime-rack: ['0.082371']
+      x-ratelimit-remaining: ['4998']
+      x-ratelimit-reset: ['1531800890']
+      x-runtime-rack: ['0.086904']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"has_wiki": false, "name": "github-file", "has_issues":
-      true, "homepage": "", "private": false, "description": "Configure your GitHub
-      repository from a file, without having to click around in the UI."}'
+    body: !!python/unicode '{"has_wiki": false, "description": "Configure your GitHub
+      repository from a file, without having to click around in the UI.", "allow_squash_merge":
+      false, "private": false, "has_issues": true, "allow_rebase_merge": true, "name":
+      "github-file", "allow_merge_commit": false, "has_projects": false, "homepage":
+      ""}'
     headers:
       Accept: [application/vnd.github.v3.full+json]
       Accept-Charset: [utf-8]
       Accept-Encoding: ['gzip, deflate']
       Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
       Connection: [keep-alive]
-      Content-Length: ['202']
+      Content-Length: ['311']
       Content-Type: [application/json]
       User-Agent: [github3.py/1.1.0]
     method: PATCH
@@ -83,30 +85,30 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6WYYW/iOBCG/0rE16MNUNhrkaq91W3V6+na3Tuxd6t+QSYxxG1iZ20HFqL+93tt
-        B5KgClosVRUYz+PxeGY847LD4s64P+yNrvrDUb/b4SKmUzPWuf98s/qS/plGt1cb8v2fZcSffz58
-        /tT/MrnpPUxurjuYTDKKmQumk2J2NmcpxeC8SNNp9csTiX4UVDIatueIFaeyMy47qVgwDsRuIgBm
-        9YvL/uCy11bn7w//fn9Io6f74f3kbnj/6dqoQJZEEzktZApKonWuxmHoBtXg3K1aKCojwTXl+jwS
-        WViEDv9xeT0EYiEriN02BvZgOas4ThgwFTb1TXSW7ing1rXzmzPnIk3FCvL7+h5cItyJGetaBOOL
-        UxAQK0OhEwqDYRsvZvNM6XeqY0VKnKjS8BQDUTgCSeP3qVQJQSHjDC9lKGkuLK2YqUiyXDPB36la
-        SxQoIReEsw05AQVRBYJR6p1KWBGI0iUc7p2yTqYMc8mWJFobc0gaUbaEdU/h7QkDp9e5idlvOH9j
-        a6bplMSZCcI5SRV96Xbs2hqT7EAXUfUm/94L8ZjuDhHL/S74nC0KSYO1KGRwy/QfxSywlmJayHUw
-        lyILSGBySDdYIaGIQgcJWcJlAy2CKGXRc0CkKHgcMB7Ah4Nvd+fYwVzI552qByPXrlbH456+hnPk
-        sA4AEKMQhzrPdO1BMdJliP9VYEWIdjITksBGHtgWpgybX42HaUoyD7oVByYRwseCVhwYplRB3+Ts
-        h87DUlS4jSdeZDOX8N4SRYfATh56EqXYglPqYbkdogy3+XgmCY8SH+iWUIbukz1hsvBQ00gDMkvF
-        zIOCOzG0iDJUCXF3j576aWaYhtBCSjr3VNMQdkgtvc7YqmgQOyAuPo3j9tBxSwjLypIp4YuCLHyY
-        OwRO2lzNC7I5WqgcipOaAaCpviSbFb5prKYYLV2dgLj2MWUNqZG29DhczRzceqOAsZvPMnasEDjE
-        qwAtJ/eGGr/cB5vvx2uWY6oaQhnWGdcl9Ip9ulWrjL7VsblCVdx7uMGWEJa/5EQnJjthoZxIerrC
-        FSAsZwR11fn5eZlQYuvljEqvWHXyABEZJagNT9ex3BJQv2RE2yp8blSMUZWngsQeNt0hgHOHd7qe
-        Tr555jnaTA/lrHiTl6HyVFpwnxxaM5pkLjSbs+gtTcih0Gphyo+K8Yh2SZp24aWaRQx+i2LZnB1K
-        RupjGyePLaC9dx1ISuHCHtaW1BHK0DWMMc1TsfbMNQ2ICVdJ0bTEU6LRbgx6/cuz3q9n/f6kPxr3
-        +uNh7xFzijx+Zc5oMhiMB6PxhZ2TFyp5BTO4GOOvd2WmIHVWnoxPeG7Af7x/tLv9Zndhng8gplRS
-        i/1WC41ffSWphKIULrkXN29db7l/hx0ThJKJyGiOSsK9hCi2wadRqyKI0IPBxnicWRGNUhW3bz20
-        rSIg/nWNJo4bJFFTF7+dsZaF6SgxkkvxRCOtmmN1xmhMXLFnVveiRtIUOrsR17fVGmRMSlE9CHEE
-        +S5J4nGnamhFTnmlUVN1FlGusN3SNHHYAC5taF+9ZN3fTYK/qhkwRx7/rF7J7ibGsdrPT+3nHLSu
-        BqzCCth4YYs+TG7Tp8f/RpvHyc2mg+bb9ZHGug0tW9a2X2I6J0Wqp67EN8oSpW1Hn1OZwdrm7cRs
-        pertnd2Nb2/tbRKg+4xVkUbEaqp+FAQ+am+X7TT3ix2CrUwh0/5FUnO7tWU41Su0ww3bNku16qj6
-        L/8Dr1WYmXwUAAA=
+        H4sIAAAAAAAAA6WYYW/bNhCG/4rgr3MiK3HSxEDQFWvQZVjSbnC3Il8MWqItJhKpkpRdW8h/30tS
+        tiSvsBPzi2HLvIcvj3fUHaseS3qjaDi4uI6GF1G/x0VCJ+ZZ7/7j7fJz9kcWf7pek29/L2L+/OPh
+        44fo8/h28DC+velhMMkpRs6ZTsvpyYxlFA9nZZZN6n+eSPy9pJLRsDtGLDmVvVHVy8SccSC2AwEw
+        s59fRWdXg66cvy7/+faQxU/3w/vx3fD+w42RQBZEEzkpZQZKqnWhRmHoHqqzUzdrqaiMBdeU69NY
+        5GEZOvz7xc0QiLmsIXbZeLADK1jNccaAqbCtN9V5tiPAzWvHt0fORJaJJex39e6dItyaGe9aBOPz
+        YxAwq0KhUwqHYRkvZvFM6TfKsSYVdlRpRIqBKGyBpMnbJNVGEGSC4aUKJS2EpZVTFUtWaCb4G6V1
+        TIESck44W5MjUDBVIBhRbxRhTWBKFwi4N9o6myosJFuQeGXcIWlM2QLePYa3YwycXhUmZ79i/42v
+        maYTkuQmCWckU/Sl37NzawyyD/rIqlfF906KJ3S7iZjuN8FnbF5KGqxEKYNPTP9eTgPrKaaFXAUz
+        KfKABOYM6QdLHCii1EFKFgjZQIsgzlj8HBApSp4EjAeI4eDr3SlWMBPyeSt1b+ba2Zp83NFrOAc2
+        aw8AOQpzyHmmKw+Ksa5CfNaJFSPbyVRIAh95YDuYKmz/NBGmKck96NYcmFQIHw9ac2CYUiV9VbDv
+        2w9LUeEmn3iZT92B95os2gd29tBJlGJzTqmH57aIKtycx1NJeJz6QDeEKnTf7A6TuYdMYw3INBNT
+        DwreiaFFVKFKiXv36ImfMsM0hA5S0pmnTEPYIrX02mMr0SC2QLz4NLbbQ+OGEFa1JzPC5yWZ+zC3
+        COy0eTXPyfpgobIvTxoGgKb6kmxa+h5jDcWodHUC8trHlQ2kQdrSY381s3fprQLGLj7P2aFCYB+v
+        BnSC3Btq4nIXbH4frlkOSTWEKmxOXHeg1+zjvVqf6BuN7Rnq4t4jDDaEsPqlIDo1pxMmKoikxwuu
+        AWE1JairTk9Pq5QSWy/nVHrlqrMHiMg4RW14vMZqQ0D9khNtq/CZkZigKs8ESTx8ukUA5zbveJ3O
+        vr3nBdpMD3HWvM3LUXkqLbjPGdow2mQuNJux+DVNyL7U6mCq94rxmPZJlvURpZrFDHGLYtnsHUpG
+        6uMbZ48loL13HUhGEcIe3pbUEarQNYwJLTKx8jxrWhCTrpKiaUkmRKPdOBtEVyeDdydRNI4uRoNo
+        NBw8YkxZJD8Z8248OB9Fl6PzoRlTlCr9H+ZyPDgbnV2PLiwGR2cdyfiG6wZ84v6j2+23uwtzfQAz
+        pdLG7NfGaPTTW5LaKM4Qkjt589r5FrvvsEOGEJmKnBaoJNxNiGJrfItwL9QqCWI0YXAybmeWRKNW
+        xeu3ebQpI2D/ZYUujhsmUROXwL2RlqVpKfGkkOKJxlo1fSYeNmdGa+SSPbPOKCOwsXOdWyMhZ1KK
+        +kqII823xySud+qWVhSU15La2llMucKCK9PGYQV4bUN+fZd1fzcO/qxHwB9F8qO+J7sbm9DqXkB1
+        L3TQvBqwCmtg644tvhx/yp4e/71YP45v1z20366TNO5tqey42/5I6IyUmZ64It+IJUrbnr6gMoe7
+        ze2JWUrd3TvHm+jebII5At13zIqDRCwn6ntJEKX2/bJ1lvvLPoOzTC2z85ek5g23sXITcaqXaIlb
+        3m2Xa/VmRS//AYS3n7KAFAAA
     headers:
       access-control-allow-origin: ['*']
       access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
@@ -116,8 +118,8 @@ interactions:
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      date: ['Sun, 15 Jul 2018 22:25:30 GMT']
-      etag: [W/"4e2c4803d93792997d5710f373e899cd"]
+      date: ['Tue, 17 Jul 2018 03:16:34 GMT']
+      etag: [W/"d7e3c99a6e0072154d8832f13b27f455"]
       referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       server: [GitHub.com]
       status: [200 OK]
@@ -126,11 +128,11 @@ interactions:
       x-content-type-options: [nosniff]
       x-frame-options: [deny]
       x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['8982:7DB6:A098CD2:147496D3:5B4BC9DA']
+      x-github-request-id: ['808A:7DB4:4FC3D37:B326048:5B4D5F92']
       x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4998']
-      x-ratelimit-reset: ['1531697130']
-      x-runtime-rack: ['0.094512']
+      x-ratelimit-remaining: ['4997']
+      x-ratelimit-reset: ['1531800890']
+      x-runtime-rack: ['0.115527']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/cassettes/test_update_uses_the_provided_filename.yaml
+++ b/tests/cassettes/test_update_uses_the_provided_filename.yaml
@@ -14,30 +14,30 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6WYYW/bNhCG/4rgr3MsK3Ha1EDQFWvQZVjSbnC3Il8MWqItJhKpkpRdW8h/30tS
-        tiSvsBPzi2HLvIcvj3fUHaseS3rjaDS8fBeNLqN+j4uETs2z3t3Hm9Xn7I8s/vRuQ779vYz504/7
-        jx+iz5Ob4f3k5rqHwSSnGLlgOi1nZ3OWUTycl1k2rf95JPH3kkpGw+4YseJU9sZVLxMLxoHYDQTA
-        zH5xFZ1fDbty/nrzz7f7LH68G91Nbkd3H66NBLIkmshpKTNQUq0LNQ5D91CdD9yspaIyFlxTrgex
-        yMMydPj3y+sREAtZQ+yy8WAPVrCa44wBU2Fbb6rzbE+Am9eOb4+ciywTK9jv6z04RbgzM961CMYX
-        pyBgVoVCpxQOwzKezeKZ0q+UY00q7KjSiBQDUdgCSZPXSaqNIMgEw3MVSloISytnKpas0EzwV0rr
+        H4sIAAAAAAAAA6WYb2/bNhDGv4rgt3Miy3Ha1EDQFWvQZVjSbnC3Im8MWqItJhKpkpRdW8h338M/
+        smR3sBPrjWHLvB8fHu+oO1Y9lvTG0Whw+S4aXUb9HhcJnZpnvbuPN6vP2R9Z/Ondhnz7exnzpx/3
+        Hz9Enyc3g/vJzXUPg0lOMXLBdFrOzuYso3g4L7Ns6v95JPH3kkpGw90xYsWp7I2rXiYWjAOxHQiA
+        mf3iKhpeDXbl/PXmn2/3Wfx4N7qb3I7uPlwbCWRJNJHTUmagpFoXahyG7qEanrtZS0VlLLimXJ/H
+        Ig/L0OHfL69HQCykh9hl48EerGCe44wBU2Fbb6rzbE+Am9eOb4+ciywTK9jv6z04Rbg1M961CMYX
+        pyBgVoVCpxQOwzKezeKZ0q+UY00q7KjSiBQDUdgCSZPXSfJGEGSC4bkKJS2EpZUzFUtWaCb4K6Xt
         mAIl5IJwtiEnoGCqQDCiXinCmsCULhFwr7R1NlVYSLYk8dq4Q9KYsiW8ewpvzxg4vS5Mzn7F/htf
-        M02nJMlNEs5Jpuhzv2fn1hhkH/SRVS+K770UT+huEzHdb4LP2aKUNFiLUgafmP69nAXWU0wLuQ7m
-        UuQBCcwZ0g9WOFBEqYOULBGygRZBnLH4KSBSlDwJGA8Qw8HX2wFWMBfyaSf1YOba2Zp83NNrOEc2
-        6wAAOQpzyHmiaw+Ksa5CfNaJFSPbyUxIAh95YDuYKmz/NBGmKck96NYcmFQIHw9ac2CYUiV9UbAf
-        2g9LUeE2n3iZz9yB95IsOgR29tBJlGILTqmH53aIKtyexzNJeJz6QLeEKnTf7A6ThYdMYw3ILBMz
-        DwreiaFFVKFKiXv36KmfMsM0hA5S0rmnTEPYIbX02mMr0SB2QLz4NLbbQ+OWEFa1JzPCFyVZ+DB3
-        COy0eTUvyOZooXIoTxoGgKb6kmxW+h5jDcWodHUC8trHlQ2kQdrS43A1c3DprQLGLj7P2bFC4BCv
-        BnSC3Btq4nIfbH4fr1mOSTWEKmxOXHeg1+zTvVqf6FuN7Rnq4t4jDLaEsPqlIDo1pxMmKoikpwuu
-        AWE1I6irBoNBlVJi6+WcSq9cdfYAERmnqA1P11htCahfcqJtFT43EhNU5ZkgiYdPdwjg3OadrtPZ
-        t/e8QJvpIc6at3k5Kk+lBfc5QxtGm8yFZnMWv6QJOZRaHUz1XjEe0z7Jsj6iVLOYIW5RLJu9Q8lI
-        fXzj7LEEtPeuA8koQtjD25I6QhW6hjGhRSbWnmdNC2LSVVI0LcmUaLQb58Po6mz49iyKJtHleBiN
-        R8MHjCmL5Cdj3k6Go/FFNI6uzJiiVOn/MHbI+fl4dGGG4OisIxnfcN2AT9x/dLv9dndhrg9gplTa
-        mP3aGI1/ektSG8UZQnIvb14633L/HXbMECJTkdMClYS7CVFsg28R7oVaJUGMJgxOxu3MimjUqnj9
-        No+2ZQTsv6zRxXHDJGrqErg31rI0LSWeFFI80lirps/Ew+bMaI1csSfWGWUENnauc2sk5ExKUV8J
-        caT57pjE9U7d0oqC8lpSWzuLKVdYcGXaOKwAr23Ir++y7m4nwZ/1CPijSH7U92S3ExNa3Quo7oUO
-        mlcDVmENbN2xxW8mn7LHh38vNw+Tm00P7bfrJI17Wyo77rY/EjonZaanrsg3YonStqcvqMzhbnN7
-        YpZSd/fO8Sa6t5tgjkD3HbPiIBGrqfpeEkSpfb/snOX+ss/gLFPL7P0lqXnDba3cRJzqFVrilnfb
-        5Vq9WdHzfxVRe9SAFAAA
+        M02nJMlNEs5Jpuhzv2fn1hhkH/SRVS+K770UT+h2EzHdb4LP2aKUNFiLUgafmP69nAXWU0wLuQ7m
+        UuQBCcwZ0g9WOFBEqYOULBGygRZBnLH4KSBSlDwJGA8Qw8HX23OsYC7k01bqwcy1szX5uKfXcI5s
+        1gEAchTmkPNE1x0oxroK8ekTK0a2k5mQBD7qgN3BVGH7p4kwTUnegW7NgUmF6OJBaw4MU6qkLwr2
+        Q/thKSqs84mX+cwdeC/JokNgZw+dRCm24JR28NwWUYX1eTyThMdpF2hNqEL3ze4wWXSQaawBmWVi
+        1oGCd2JoEVWoUuLePXraTZlhGsIOUtJ5R5mGsEVq2WmPrUSD2ALx4tPY7g4aa0JYeU9mhC9KsujC
+        3CKw0+bVvCCbo4XKoTxpGACa6kuyWdn1GGsoRqWrE5DXXVzZQBqkLT0OVzMHl94qYOzi85wdKwQO
+        8TxgJ8g7Q01c7oPN7+M1yzGphlCFzYnrDnTPPt2r/kSvNbZn8MV9hzCoCWH1S0F0ak4nTFQQSU8X
+        7AFhNSOoq87Pz6uUElsv51R2ylVnDxCRcYra8HSNVU1A/ZITbavwuZGYoCrPBEk6+HSLAM5t3uk6
+        nX17zwu0mR3EWfM2L0flqbTgXc7QhtEmc6HZnMUvaUIOpdYOpnqvGI9pn2RZH1GqWcwQtyiWzd6h
+        ZKRdfOPssQS0964DyShCuIO3JXWEKnQNY0KLTKw7njUtiElXSdG0JFOi0W4MB9HV2eDtWRRNosvx
+        IBqPBg8YUxbJz2OG0QQDhhh2YcYUpUp/wlxNBm/HF4NxNDRDcHT6SMY3XDfgE/cfu91+u7sw1wcw
+        UyptzH5tjMb/e0vijeIMIbmXNy+db7n/DjtmCJGpyGmBSsLdhCi2wbcL3Au1SoIYTRicfNHvrYhG
+        rYrXb/OoLiNg/2WNLo4bJlFTl8C9sZalaSnxpJDikcZaNX0mHjZnRmvkij2xnVFGYGPnOjcvAXdG
+        OZNS+CshjjTfHpO43vEtrSgo95Jq7VgjekzKFRZcmTYOK8BrG/L9Xdbd7ST404+AP4rkh78nu52Y
+        0Nq9gNq90PFgFXpg644tfjP5lD0+/Hu5eZjcbHpov10nOcZCWipxR9e42/o+oXNSZnrqinwjliht
+        e/qCyhzuNrcnZim+u3eON9Fdb4I5At13zIqDRKym6ntJEKX2/bJ1lvvLPoOzTC2z95ek5g1XW7mJ
+        ONUrtMS1d7GadrnmNyt6/g9rgnKJgBQAAA==
     headers:
       access-control-allow-origin: ['*']
       access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
@@ -47,9 +47,9 @@ interactions:
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 17 Jul 2018 04:32:25 GMT']
-      etag: [W/"92f1cfadbb4c24b21c8dac5d1504361d"]
-      last-modified: ['Tue, 17 Jul 2018 04:31:18 GMT']
+      date: ['Sat, 21 Jul 2018 01:25:57 GMT']
+      etag: [W/"3cc92b01e5ab9b3c21ab9210f28a67b9"]
+      last-modified: ['Sat, 21 Jul 2018 01:25:03 GMT']
       referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       server: [GitHub.com]
       status: [200 OK]
@@ -58,11 +58,11 @@ interactions:
       x-content-type-options: [nosniff]
       x-frame-options: [deny]
       x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['853C:7DB6:ABFE3CF:15E81EBD:5B4D7158']
+      x-github-request-id: ['9BD0:413C:FA8A38:1CB9BE8:5B528BA4']
       x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4984']
-      x-ratelimit-reset: ['1531804963']
-      x-runtime-rack: ['0.067013']
+      x-ratelimit-remaining: ['4976']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.068907']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -85,30 +85,30 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6WYYW/bNhCG/4rgr3Miy3Ha1EDQFWvQZVjSbnC3Il8MWqItJhKpkpRdW8h/30tS
-        tiSvsBPzi2HLvIcvj3fUHaseS3rjaDS4fBeNLqN+j4uETs2z3t3Hm9Xn7I8s/vRuQ779vYz504/7
-        jx+iz5Obwf3k5rqHwSSnGLlgOi1nZ3OWUTycl1k2rf95JPH3kkpGw+4YseJU9sZVLxMLxoHYDQTA
-        zH5xFQ2vBl05f73559t9Fj/eje4mt6O7D9dGAlkSTeS0lBkoqdaFGoehe6iG527WUlEZC64p1+ex
-        yMMydPj3y+sREAtZQ+yy8WAPVrCa44wBU2Fbb6rzbE+Am9eOb4+ciywTK9jv6z04RbgzM961CMYX
-        pyBgVoVCpxQOwzKezeKZ0q+UY00q7KjSiBQDUdgCSZPXSaqNIMgEw3MVSloISytnKpas0EzwV0rr
-        mAIl5IJwtiEnoGCqQDCiXinCmsCULhFwr7R1NlVYSLYk8dq4Q9KYsiW8ewpvzxg4vS5Mzn7F/htf
-        M02nJMlNEs5Jpuhzv2fn1hhkH/SRVS+K770UT+huEzHdb4LP2aKUNFiLUgafmP69nAXWU0wLuQ7m
-        UuQBCcwZ0g9WOFBEqYOULBGygRZBnLH4KSBSlDwJGA8Qw8HX23OsYC7k007qwcy1szX5uKfXcI5s
-        1gEAchTmkPNE1x4UY12F+KwTK0a2k5mQBD7ywHYwVdj+aSJMU5J70K05MKkQPh605sAwpUr6omA/
-        tB+WosJtPvEyn7kD7yVZdAjs7KGTKMUWnFIPz+0QVbg9j2eS8Dj1gW4JVei+2R0mCw+ZxhqQWSZm
-        HhS8E0OLqEKVEvfu0VM/ZYZpCB2kpHNPmYawQ2rptcdWokHsgHjxaWy3h8YtIaxqT2aEL0qy8GHu
-        ENhp82pekM3RQuVQnjQMAE31Jdms9D3GGopR6eoE5LWPKxtIg7Slx+Fq5uDSWwWMXXyes2OFwCFe
-        DegEuTfUxOU+2Pw+XrMck2oIVdicuO5Ar9mne7U+0bca2zPUxb1HGGwJYfVLQXRqTidMVBBJTxdc
-        A8JqRlBXnZ+fVykltl7OqfTKVWcPEJFxitrwdI3VloD6JSfaVuFzIzFBVZ4Jknj4dIcAzm3e6Tqd
-        fXvPC7SZHuKseZuXo/JUWnCfM7RhtMlcaDZn8UuakEOp1cFU7xXjMe2TLOsjSjWLGeIWxbLZO5SM
-        1Mc3zh5LQHvvOpCMIoQ9vC2pI1ShaxgTWmRi7XnWtCAmXSVF05JMiUa7MRxEV2eDt2dRNIkux4No
-        PBo8YExZJD8Z83YyGI0vhuPhpRlTlCr9H8YOGQ7HowszBEdnHcn4husGfOL+o9vtt7sLc30AM6XS
-        xuzXxmj801uS2ijOEJJ7efPS+Zb777BjhhCZipwWqCTcTYhiG3yLcC/UKgliNGFwMm5nVkSjVsXr
-        t3m0LSNg/2WNLo4bJlFTl8C9sZalaSnxpJDikcZaNX0mHjZnRmvkij2xzigjsLFznVsjIWdSivpK
-        iCPNd8ckrnfqllYUlNeS2tpZTLnCgivTxmEFeG1Dfn2XdXc7Cf6sR8AfRfKjvie7nZjQ6l5AdS90
-        0LwasAprYOuOLX4z+ZQ9Pvx7uXmY3Gx6aL9dJ2nc21LZcbf9kdA5KTM9dUW+EUuUtj19QWUOd5vb
-        E7OUurt3jjfRvd0EcwS675gVB4lYTdX3kiBK7ftl5yz3l30GZ5laZu8vSc0bbmvlJuJUr9ASt7zb
-        LtfqzYqe/wOdAmTxgBQAAA==
+        H4sIAAAAAAAAA6WYb2/iOBDGv0rE26OEULrtIlV7q9uq19O1u3di71Z9g0xiiNskztoOLET97vf4
+        DySwJ2jxGwTB8/Pj8Ywz47rDks4oGvYv3kfDi6jbKXhCJ/pZ5/7TzfJz9kcW375fk29/L+Li+cfD
+        p4/R5/FN/2F8c93BYJJTjJwzlVbTsxnLKB7OqiybuH+eSPy9ooLRcHcMXxZUdEZ1J+NzVgCxHQiA
+        nv38Khpc9Xfl/PXun28PWfx0P7wf3w3vP15rCWRBFBGTSmSgpEqVchSG9qEc9OyslaQi5oWiherF
+        PA+r0OI/LK6HQMyFg5hl48EerGSOY40Bk2Fbb6rybE+AndeMb4+c8SzjS9jv6z04Rbg10941CFbM
+        T0HArA65SikchmW86MUzqd4ox5jU2FGpECkaIrEFgiZvk+SMIEgHw0sdClpyQ6umMhasVIwXb5S2
+        YwoUF3NSsDU5AQVTCYIW9UYRxgSmdIGAe6OttanDUrAFiVfaHYLGlC3g3VN4e8bAqVWpc/Yr9l/7
+        mik6IUmuk3BGMklfuh0zt8Ig86CLrHpVfO+leEK3m4jpfuPFjM0rQYMVr0Rwy9Tv1TQwnmKKi1Uw
+        EzwPSKDPkG6wxIHCKxWkZIGQDRQP4ozFzwERvCqSgBUBYjj4etfDCmZcPG+lHsxcM1uTj3t6NefI
+        Zh0AIEdhDjnPdOVB0dZ1iE+XWDGynUy5IPCRB3YHU4ftnzrCFCW5B92YA5Ny7uNBYw4Mk7Kirwr2
+        Q/thKDLc5FNR5VN74L0miw6BrT10EinZvKDUw3NbRB1uzuOpIEWc+kA3hDq038wOk7mHTG0NyDTj
+        Uw8K3omhQdShTIl996iJnzLN1IQdpKAzT5masEUq4bXHRqJGbIF48Slst4fGDSGsnSczUswrMvdh
+        bhHYaf1qnpP10ULlUJ40DAB19SXYtPI9xhqKVmnrBOS1jysbSIM0pcfhaubg0lsFjFl8nrNjhcAh
+        ngPsBLk3VMflPlj/Pl6zHJOqCXXYnLj2QHfs073qTvSNxvYMrrj3CIMNIax/KYlK9emEiUoi6OmC
+        HSCspwR1Va/Xq1NKTL2cU+GVq9YeICLiFLXh6RrrDQH1S06UqcJnWmKCqjzjJPHw6RYBnN2803Va
+        +/ael2gzPcQZ8zYvR+UpFS98ztCG0SYXXLEZi1/ThBxKrR1M/UGyIqZdkmVdRKliMUPcoljWe4eS
+        kfr4xtpjCWjvbQeSUYSwh7cFtYQ6tA1jQsuMrzzPmhZEp6ugaFqSCVFoNwb96Oqsf3kWRePoYtSP
+        RsP+I8ZUZfLzmEE0xoDBxejiUo8pK5n+hLka9y9H5/1RNNBDcHS6SMY3XDfgE/cfu91+u7vQ1wcw
+        kzJtzH5tjEb/e0vijOIMIbmXN6+db7H/DjtmCJEpz2mJSsLehEi2xrdz3Au1SoIYTRicfN7tLIlC
+        rYrXb/NoU0bA/ssKXVyhmURObAJ3RkpUuqXEk1LwJxor2fSZeNicGa2RS/bMdkZpgY2d7dycBNwZ
+        5UwI7q6ECqT59pjE9Y5raXlJCydpox1rRI9JC4kF17qNwwrw2oZ8d5d1fzcO/nQj4I8y+eHuye7G
+        OrR2L6B2L3QcWIYO2Lpji9+Nb7Onx38v1o/jm3UH7bftJEdYSEsl7ugadxvfJ3RGqkxNbJGvxRKp
+        TE9fUpHD3fr2RC/FdffW8Tq6N5ugj0D7HbPiIOHLifxeEUSpeb9snWX/Ms/gLF3L7P0lqH7Dbazs
+        RAVVS7TEG+9iNe1yzW1W9PIf4wrn54AUAAA=
     headers:
       access-control-allow-origin: ['*']
       access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
@@ -118,8 +118,8 @@ interactions:
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 17 Jul 2018 04:32:25 GMT']
-      etag: [W/"2b16f79d5910ccf732ccb6923b737231"]
+      date: ['Sat, 21 Jul 2018 01:25:57 GMT']
+      etag: [W/"e0947b2fdc6c88541c0beaa32a7f9bbb"]
       referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       server: [GitHub.com]
       status: [200 OK]
@@ -128,13 +128,713 @@ interactions:
       x-content-type-options: [nosniff]
       x-frame-options: [deny]
       x-github-media-type: [github.v3; param=full; format=json]
-      x-github-request-id: ['853C:7DB6:ABFE3FC:15E81F22:5B4D7159']
+      x-github-request-id: ['9BD0:413C:FA8A54:1CB9C0F:5B528BA5']
       x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4983']
-      x-ratelimit-reset: ['1531804963']
-      x-runtime-rack: ['0.102689']
+      x-ratelimit-remaining: ['4975']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.084991']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: GET
+    uri: https://api.github.com/repos/jacquerie/github-file/labels?per_page=100
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62VTW+bQBCG/8oKqcrFDdjYYPtmKR8n99JUlRpV1ZodYJ1ll+5HcV3lv3fAwaR2
+        FSwFLmjeWQ165t0ZHv94nHnLcRAEk/l8spiNPKkY/KhFb33zJXq4v+Pfvla79c2qWm+z6Xr7NPZG
+        ntMCD+TWlmbp+7Tk1xm3udtcJ6rwNZTK+Fua/HSgOfiH1MeUC/AF3YAw/sZlWEXSArDMIUiUUBoj
+        Fod0SjHLIKVOWG9ptYM6NInmpeVK4qnPqgCbc5kRbuSVJZXSTxh5z6MTougCoskARMyVgifUQsf1
+        WmrpkpSFLO6je8i5QTDjgChNSicE0YDdNJZQoYGy3wR23FhzzhtfwBsOwAsypzKBAqTtiP8VW2Y6
+        AYC0j/kTVCQFap1uoF94TwHDoN/Q/WoIQzOl2IdJkHJtLL4bNzrSOkua3MEnzLS4cTCL017c+6YA
+        gkqocGhAn3kZBv1e7ldDeJmDKBGxotIC6xhrmRzFFi8I5lFcN/jN+bzdWU0JtRbvB04sNglBgWH5
+        kwkNg3nvjd2vpvi99+4cLn9RgYvtuHc6oWWDKUTRoo+tmU6moFk8BqAgmme5PSdbXEA2G4Cs2Qz1
+        XjyivVKOe3UeR1Dfljd9u3Pa5qAJl3g3C9p69zKN/7FvHPRD3lYDQFZK2pTvOsZOaBHT5ulDbOyr
+        OO5UqSzZQPPvAEawf8/f/wK1Q1+LEQcAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 21 Jul 2018 01:25:57 GMT']
+      etag: [W/"eb828e900827a42324c0fe01d1659f92"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['9BD0:413C:FA8A6C:1CB9C59:5B528BA5']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4974']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.051719']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/bug
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Sat, 21 Jul 2018 01:25:57 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['9BD0:413C:FA8A79:1CB9C7B:5B528BA5']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4973']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.056936']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/duplicate
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Sat, 21 Jul 2018 01:25:57 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['9BD0:413C:FA8A85:1CB9C9A:5B528BA5']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4972']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.074165']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/enhancement
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Sat, 21 Jul 2018 01:25:58 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['9BD0:413C:FA8AA7:1CB9CC4:5B528BA5']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4971']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.074014']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Sat, 21 Jul 2018 01:25:58 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['9BD0:413C:FA8ABB:1CB9D0D:5B528BA6']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4970']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.059438']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Sat, 21 Jul 2018 01:25:58 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['9BD0:413C:FA8ACC:1CB9D2B:5B528BA6']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4969']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.063209']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/invalid
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Sat, 21 Jul 2018 01:25:58 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['9BD0:413C:FA8AE3:1CB9D55:5B528BA6']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4968']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.057132']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/question
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['9BD0:413C:FA8AF9:1CB9D88:5B528BA6']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4967']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.083807']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/vnd.github.v3.full+json]
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: DELETE
+    uri: https://api.github.com/repos/jacquerie/github-file/labels/wontfix
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-security-policy: [default-src 'none']
+      content-type: [application/octet-stream]
+      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [204 No Content]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.v3; param=full; format=json]
+      x-github-request-id: ['9BD0:413C:FA8B0D:1CB9DB2:5B528BA7']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4966']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.068660']
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{"color": "d73a4a", "name": "bug", "description": "Something
+      isn''t working"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['76']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1000288726,"node_id":"MDU6TGFiZWwxMDAwMjg4NzI2","url":"https://api.github.com/repos/jacquerie/github-file/labels/bug","name":"bug","color":"d73a4a","default":true,"description":"Something
+        isn''t working"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['209']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
+      etag: ['"70c69d3c2e74371cdb1556aa91a1ae3b"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/bug']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['9BD0:413C:FA8B23:1CB9DD4:5B528BA7']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4965']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.059677']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "cfd3d7", "name": "duplicate", "description":
+      "This issue or pull request already exists"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1000288737,"node_id":"MDU6TGFiZWwxMDAwMjg4NzM3","url":"https://api.github.com/repos/jacquerie/github-file/labels/duplicate","name":"duplicate","color":"cfd3d7","default":true,"description":"This
+        issue or pull request already exists"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['239']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
+      etag: ['"a7e75964d64e4f3dead233738f0127e1"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/duplicate']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['9BD0:413C:FA8B3A:1CB9E06:5B528BA7']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4964']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.055315']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "a2eeef", "name": "enhancement", "description":
+      "New feature or request"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['83']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1000288738,"node_id":"MDU6TGFiZWwxMDAwMjg4NzM4","url":"https://api.github.com/repos/jacquerie/github-file/labels/enhancement","name":"enhancement","color":"a2eeef","default":true,"description":"New
+        feature or request"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['224']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
+      etag: ['"42e63ee987ce88605b9df8d14f497624"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/enhancement']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['9BD0:413C:FA8B53:1CB9E2B:5B528BA7']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4963']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.052768']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "7057ff", "name": "good first issue", "description":
+      "Good for newcomers"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['84']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1000288739,"node_id":"MDU6TGFiZWwxMDAwMjg4NzM5","url":"https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue","name":"good
+        first issue","color":"7057ff","default":true,"description":"Good for newcomers"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['234']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 21 Jul 2018 01:25:59 GMT']
+      etag: ['"b3461ff5f59a8105635b1261587a5642"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/good%20first%20issue']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['9BD0:413C:FA8B66:1CB9E52:5B528BA7']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4962']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.057105']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "008672", "name": "help wanted", "description":
+      "Extra attention is needed"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['86']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1000288740,"node_id":"MDU6TGFiZWwxMDAwMjg4NzQw","url":"https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted","name":"help
+        wanted","color":"008672","default":true,"description":"Extra attention is
+        needed"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['229']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 21 Jul 2018 01:26:00 GMT']
+      etag: ['"69e2e9a9134e3fd94d29b23709b5fa1d"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/help%20wanted']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['9BD0:413C:FA8B80:1CB9E83:5B528BA7']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4961']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.058553']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "e4e669", "name": "invalid", "description":
+      "This doesn''t seem right"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['80']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1000288741,"node_id":"MDU6TGFiZWwxMDAwMjg4NzQx","url":"https://api.github.com/repos/jacquerie/github-file/labels/invalid","name":"invalid","color":"e4e669","default":true,"description":"This
+        doesn''t seem right"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['217']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 21 Jul 2018 01:26:00 GMT']
+      etag: ['"37eb7d37fa59b47711f74653ad82301b"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/invalid']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['9BD0:413C:FA8BA2:1CB9EBB:5B528BA8']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4960']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.063497']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "d876e3", "name": "question", "description":
+      "Further information is requested"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['90']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1000288742,"node_id":"MDU6TGFiZWwxMDAwMjg4NzQy","url":"https://api.github.com/repos/jacquerie/github-file/labels/question","name":"question","color":"d876e3","default":true,"description":"Further
+        information is requested"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['228']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 21 Jul 2018 01:26:00 GMT']
+      etag: ['"b411c7446fab5e80a2b026ebfb444f59"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/question']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['9BD0:413C:FA8BD0:1CB9F04:5B528BA8']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4959']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.064102']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: !!python/unicode '{"color": "ffffff", "name": "wontfix", "description":
+      "This will not be worked on"}'
+    headers:
+      Accept: [!!python/unicode 'application/vnd.github.symmetra-preview+json']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic dXNlcm5hbWU6cGFzc3dvcmQ=]
+      Connection: [keep-alive]
+      Content-Length: ['83']
+      Content-Type: [application/json]
+      User-Agent: [github3.py/1.1.0]
+    method: POST
+    uri: https://api.github.com/repos/jacquerie/github-file/labels
+  response:
+    body: {string: !!python/unicode '{"id":1000288743,"node_id":"MDU6TGFiZWwxMDAwMjg4NzQz","url":"https://api.github.com/repos/jacquerie/github-file/labels/wontfix","name":"wontfix","color":"ffffff","default":true,"description":"This
+        will not be worked on"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      content-length: ['220']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 21 Jul 2018 01:26:00 GMT']
+      etag: ['"a11d56874c16d6cebf1029e74a2200e1"']
+      location: ['https://api.github.com/repos/jacquerie/github-file/labels/wontfix']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      server: [GitHub.com]
+      status: [201 Created]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      vary: ['Accept, Authorization, Cookie, X-GitHub-OTP']
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-github-media-type: [github.symmetra-preview; format=json]
+      x-github-request-id: ['9BD0:413C:FA8BEE:1CB9F48:5B528BA8']
+      x-ratelimit-limit: ['5000']
+      x-ratelimit-remaining: ['4958']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.067310']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
 - request:
     body: !!python/unicode '{"names": ["github", "configuration", "file"]}'
     headers:
@@ -162,7 +862,7 @@ interactions:
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 17 Jul 2018 04:32:26 GMT']
+      date: ['Sat, 21 Jul 2018 01:26:00 GMT']
       etag: [W/"a3d0f31fe3b28b17d94593008a4c5352"]
       referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       server: [GitHub.com]
@@ -172,11 +872,11 @@ interactions:
       x-content-type-options: [nosniff]
       x-frame-options: [deny]
       x-github-media-type: [github.mercy-preview; format=json]
-      x-github-request-id: ['853C:7DB6:ABFE41C:15E81F86:5B4D7159']
+      x-github-request-id: ['9BD0:413C:FA8C1F:1CB9F99:5B528BA8']
       x-ratelimit-limit: ['5000']
-      x-ratelimit-remaining: ['4982']
-      x-ratelimit-reset: ['1531804963']
-      x-runtime-rack: ['0.195925']
+      x-ratelimit-remaining: ['4957']
+      x-ratelimit-reset: ['1532139803']
+      x-runtime-rack: ['0.124670']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ owner = jacquerie
 repo = github-file
 description = Configure your GitHub repository from a file,
     without having to click around in the UI.
+topics = github, configuration, file
 
 [features]
 has_issues = true

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,34 +2,95 @@
 
 from __future__ import absolute_import, division, print_function
 
+from textwrap import dedent
+
 import pytest
 
 from github_file.cli import cli
 
-GITHUB_FILE = '''\
-[core]
-owner = jacquerie
-repo = github-file
-description = Configure your GitHub repository from a file,
-    without having to click around in the UI.
-topics = github, configuration, file
 
-[features]
-has_issues = true
-has_projects = false
-has_wiki = false
+@pytest.mark.vcr()
+def test_update_can_set_the_description(runner, tmpdir):
+    config_fd = tmpdir.join('Githubfile')
+    config_fd.write(dedent(u'''\
+    [core]
+    owner = jacquerie
+    repo = github-file
+    description = Configure your GitHub repository from a file,
+        without having to click around in the UI.
+    '''))
 
-[merges]
-allow_squash_merge = false
-allow_merge_commit = false
-allow_rebase_merge = true
-'''
+    result = runner.invoke(cli, ['update', '-f', str(config_fd)])
+
+    assert 0 == result.exit_code
 
 
 @pytest.mark.vcr()
-def test_update_uses_the_provided_filename(runner, tmpdir):
+def test_update_can_set_the_topics(runner, tmpdir):
     config_fd = tmpdir.join('Githubfile')
-    config_fd.write(GITHUB_FILE)
+    config_fd.write(dedent(u'''\
+    [core]
+    owner = jacquerie
+    repo = github-file
+    topics = github, configuration, file
+    '''))
+
+    result = runner.invoke(cli, ['update', '-f', str(config_fd)])
+
+    assert 0 == result.exit_code
+
+
+@pytest.mark.vcr()
+def test_update_can_configure_which_features_to_use(runner, tmpdir):
+    config_fd = tmpdir.join('Githubfile')
+    config_fd.write(dedent(u'''\
+    [core]
+    owner = jacquerie
+    repo = github-file
+
+    [features]
+    has_issues = true
+    has_projects = false
+    has_wiki = false
+    '''))
+
+    result = runner.invoke(cli, ['update', '-f', str(config_fd)])
+
+    assert 0 == result.exit_code
+
+
+@pytest.mark.vcr()
+def test_update_can_configure_the_issue_labels(runner, tmpdir):
+    config_fd = tmpdir.join('Githubfile')
+    config_fd.write(dedent(u'''\
+    [core]
+    owner = jacquerie
+    repo = github-file
+
+    [issues]
+    labels = enhancement, #a2eeef
+        bug, #d73a4a
+        question, #d876e3
+    '''))
+
+    result = runner.invoke(cli, ['update', '-f', str(config_fd)])
+
+    assert 0 == result.exit_code
+
+
+@pytest.mark.vcr()
+def test_update_can_configure_the_merge_policy(runner, tmpdir):
+    config_fd = tmpdir.join('Githubfile')
+    config_fd.write(dedent(u'''\
+    [core]
+    owner = jacquerie
+    repo = github-file
+
+    [merges]
+    allow_squash_merge = false
+    allow_merge_commit = false
+    allow_rebase_merge = true
+    '''))
 
     result = runner.invoke(cli, ['update', '-f', str(config_fd)])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,13 @@ description = Configure your GitHub repository from a file,
 
 [features]
 has_issues = true
+has_projects = false
 has_wiki = false
+
+[merges]
+allow_squash_merge = false
+allow_merge_commit = false
+allow_rebase_merge = true
 '''
 
 


### PR DESCRIPTION
Since `github3.py==1.2.0` has been released (https://github.com/sigmavirus24/github3.py/commit/162f247b4664a2612b2cfd959497678b069f2c5e) I can now release the alpha of `github-file` ! :tada: 